### PR TITLE
proto make: go get deprecation

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -15,6 +15,5 @@ gen-grpc:
 clean:
 	rm -rf gen/v1/l3afdconfig/l3afdconfig_service*
 deps:
-	go get -u google.golang.org/protobuf/cmd/protoc-gen-go
-	go get -u google.golang.org/grpc/cmd/protoc-gen-go-grpc
-	go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+	go install google.golang.org/protobuf/cmd/protoc-gen-go
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc 


### PR DESCRIPTION
installing executables with go get is deprecated

proto/Makefile install two programs which is not an importable package, this PR uses the go install instead of go get.

This also removes the go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger from deps recipe as starting with v2 grpc gateway which is currently being utilized in this project github.com/grpc-ecosystem/grpc-gateway/v2 v2.6.0 is not available and instead is available as openapi plugin which is also currently being utilized to generate doc.