### PR TITLE
Initial steps towards getting L3AFD on Windows

### DIFF
--- a/.github/workflows/ci-build-windows.yaml
+++ b/.github/workflows/ci-build-windows.yaml
@@ -1,0 +1,30 @@
+# Copyright Contributors to the L3AF Project.
+# SPDX-License-Identifier: Apache-2.0
+#
+# For documentation on the github environment, see
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+#
+# For documentation on the syntax of this file, see
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+name: CI Windows build
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Build
+        run: |
+          go build -tags WINDOWS .
+      
+      - name: Test
+        run: |
+          go test -tags WINDOWS ./...

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,4 +1,4 @@
-name: CI build
+name: CI Ubuntu build
 on:
   pull_request: {}
   push:

--- a/README.md
+++ b/README.md
@@ -24,3 +24,31 @@ by multiple sources.
 
 See our [L3AF Development Environment](https://github.com/l3af-project/l3af-arch/tree/main/dev_environment)
 for a quick and easy way to try out L3AF on your local machine.
+
+# Building
+
+To build on your local machine, do the following.
+
+For Linux:
+```
+go build .
+```
+
+For Windows:
+```
+go build -tags WINDOWS .
+```
+
+# Testing
+
+To test on your local machine, do the following.
+
+For Linux:
+```
+go test ./...
+```
+
+For Windows:
+```
+go test -tags WINDOWS ./...
+```

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -574,18 +574,6 @@ func (b *BPF) GetArtifacts(conf *config.Config) error {
 	return nil
 }
 
-// assertExecutable checks for executable permissions
-func assertExecutable(fPath string) error {
-	info, err := os.Stat(fPath)
-	if err != nil {
-		return fmt.Errorf("Could not stat file: %s with error: %w", fPath, err)
-	}
-	if (info.Mode()&os.ModePerm)&os.FileMode(executePerm) == 0 {
-		return fmt.Errorf("File: %s, is not executable.", fPath)
-	}
-	return nil
-}
-
 // create rules file
 func (b *BPF) createUpdateRulesFile(direction string) (string, error) {
 

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -476,20 +476,7 @@ func (b *BPF) isRunning() (bool, error) {
 		return false, errors.New("No process id found")
 	}
 
-	procState, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/stat", b.Cmd.Process.Pid))
-	if err != nil {
-		return false, fmt.Errorf("BPF Program not running %s because of error: %w", b.Program.Name, err)
-	}
-	var u1, u2, state string
-	_, err = fmt.Sscanf(string(procState), "%s %s %s", &u1, &u2, &state)
-	if err != nil {
-		return false, fmt.Errorf("Failed to scan proc state with error: %w", err)
-	}
-	if state == "Z" {
-		return false, fmt.Errorf("Process %d in Zombie state", b.Cmd.Process.Pid)
-	}
-
-	return true, nil
+    return IsProcessRunning(b.Cmd.Process.Pid, b.Program.Name)
 }
 
 // Check binary already exists

--- a/kf/bpf_test.go
+++ b/kf/bpf_test.go
@@ -166,13 +166,13 @@ func TestBPF_Stop(t *testing.T) {
 				Program: models.BPFProgram{
 					Name:          "nfprogram",
 					Artifact:      "ls.tar.gz",
-					CmdStart:      "ls",
-					CmdStop:       "ls",
+					CmdStart:      GetTestExecutableName(),
+					CmdStop:       GetTestExecutableName(),
 					IsUserProgram: false,
 					AdminStatus:   "enabled",
 				},
-				Cmd:          fakeExecCommand("/bin/ls"),
-				FilePath:     "/bin",
+				Cmd:          fakeExecCommand(GetTestExecutablePathName()),
+				FilePath:     GetTestExecutablePath(),
 				RestartCount: 3,
 			},
 			wantErr: false,
@@ -221,13 +221,13 @@ func TestBPF_Start(t *testing.T) {
 				Program: models.BPFProgram{
 					Name:          "nfprogram",
 					Artifact:      "ls.tar.gz",
-					CmdStart:      "ls",
-					CmdStop:       "ls",
+					CmdStart:      GetTestExecutableName(),
+					CmdStop:       GetTestExecutableName(),
 					IsUserProgram: true,
 					AdminStatus:   "enabled",
 				},
 				Cmd:          nil,
-				FilePath:     "/bin",
+				FilePath:     GetTestExecutablePath(),
 				RestartCount: 0,
 			},
 			wantErr: false,
@@ -237,13 +237,13 @@ func TestBPF_Start(t *testing.T) {
 				Program: models.BPFProgram{
 					Name:          "nfprogram",
 					Artifact:      "ls.tar.gz",
-					CmdStart:      "ls",
-					CmdStop:       "ls",
+					CmdStart:      GetTestExecutableName(),
+					CmdStop:       GetTestExecutableName(),
 					IsUserProgram: false,
 					AdminStatus:   "enabled",
 				},
-				Cmd:          fakeExecCommand("/bin/ls"),
-				FilePath:     "/bin",
+				Cmd:          fakeExecCommand(GetTestExecutablePathName()),
+				FilePath:     GetTestExecutablePath(),
 				RestartCount: 0,
 			},
 			wantErr: true,
@@ -253,15 +253,15 @@ func TestBPF_Start(t *testing.T) {
 				Program: models.BPFProgram{
 					Name:          "nfprogram",
 					Artifact:      "ls.tar.gz",
-					CmdStart:      "ls",
-					CmdStop:       "ls",
+					CmdStart:      GetTestExecutableName(),
+					CmdStop:       GetTestExecutableName(),
 					IsUserProgram: true,
 					AdminStatus:   "enabled",
 					CPU:           100,
 					Memory:        1024,
 				},
-				Cmd:          fakeExecCommand("/bin/ls"),
-				FilePath:     "/bin",
+				Cmd:          fakeExecCommand(GetTestExecutablePathName()),
+				FilePath:     GetTestExecutablePath(),
 				RestartCount: 0,
 			},
 			wantErr: false,
@@ -343,7 +343,7 @@ func TestBPF_GetArtifacts(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{name: "EmptyArtifcat",
+		{name: "EmptyArtifact",
 			fields: fields{
 				Program:      models.BPFProgram{},
 				Cmd:          nil,
@@ -353,7 +353,7 @@ func TestBPF_GetArtifacts(t *testing.T) {
 			args:    args{conf: &config.Config{BPFDir: "/tmp"}},
 			wantErr: true,
 		},
-		{name: "DummyArtifcat",
+		{name: "DummyArtifact",
 			fields: fields{
 				Program: models.BPFProgram{
 					Artifact: "dummy.tar.gz",
@@ -452,14 +452,14 @@ func Test_assertExecute(t *testing.T) {
 		{
 			name: "ValidFilepath",
 			args: args{
-				filepath: "/bin/ps",
+				filepath: GetTestExecutablePathName(),
 			},
 			wantErr: false,
 		},
 		{
 			name: "ValidFilepathWihoutExecute",
 			args: args{
-				filepath: "/var/log/syslog",
+				filepath: GetTestNonexecutablePathName(),
 			},
 			wantErr: true,
 		},

--- a/kf/bpf_test_unix.go
+++ b/kf/bpf_test_unix.go
@@ -1,0 +1,39 @@
+// Copyright Contributors to the L3AF Project.
+// SPDX-License-Identifier: Apache-2.0
+// +build !WINDOWS
+
+package kf
+
+import (
+	"fmt"
+	"os"
+)
+
+func GetTestNonexecutablePathName() string {
+	return "/var/log/syslog"
+}
+
+func GetTestExecutablePathName() string {
+	return "/bin/ls"
+}
+
+func GetTestExecutablePath() string {
+	return "/bin"
+}
+
+func GetTestExecutableName() string {
+	return "ls"
+}
+
+// assertExecutable checks for executable permissions
+func assertExecutable(fPath string) error {
+	info, err := os.Stat(fPath)
+	if err != nil {
+		return fmt.Errorf("Could not stat file: %s with error: %w", fPath, err)
+	}
+
+	if (info.Mode()&os.ModePerm)&os.FileMode(executePerm) == 0 {
+		return fmt.Errorf("File: %s, is not executable.", fPath)
+	}
+	return nil
+}

--- a/kf/bpf_test_windows.go
+++ b/kf/bpf_test_windows.go
@@ -11,15 +11,15 @@ import (
 )
 
 func GetTestNonexecutablePathName() string {
-	return "/windows/system32/drivers/etc/host"
+    return "c:/windows/system32/drivers/etc/host"
 }
 
 func GetTestExecutablePathName() string {
-	return "/windows/system32/net.exe"
+    return "c:/windows/system32/net.exe"
 }
 
 func GetTestExecutablePath() string {
-	return "/windows/system32"
+    return "c:/windows/system32"
 }
 
 func GetTestExecutableName() string {

--- a/kf/bpf_test_windows.go
+++ b/kf/bpf_test_windows.go
@@ -1,0 +1,43 @@
+// Copyright Contributors to the L3AF Project.
+// SPDX-License-Identifier: Apache-2.0
+// +build WINDOWS
+
+package kf
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func GetTestNonexecutablePathName() string {
+	return "/windows/system32/drivers/etc/host"
+}
+
+func GetTestExecutablePathName() string {
+	return "/windows/system32/net.exe"
+}
+
+func GetTestExecutablePath() string {
+	return "/windows/system32"
+}
+
+func GetTestExecutableName() string {
+	return "net.exe"
+}
+
+// assertExecutable checks for executable permissions
+func assertExecutable(fPath string) error {
+	_, err := os.Stat(fPath)
+	if err != nil {
+		return fmt.Errorf("Could not stat file: %s with error: %w", fPath, err)
+	}
+
+	// info.Mode() does not return the correct permissions on Windows,
+	// it always has the 'x' permissions clear, so instead use the file suffix.
+	if !strings.HasSuffix(fPath, ".exe") {
+		return fmt.Errorf("File: %s, is not executable.", fPath)
+	}
+
+	return nil
+}

--- a/kf/kf_unix.go
+++ b/kf/kf_unix.go
@@ -1,0 +1,93 @@
+// Copyright Contributors to the L3AF Project.
+// SPDX-License-Identifier: Apache-2.0
+// +build !WINDOWS
+
+// Package kf provides primitives for l3afd's network function configs.
+package kf
+
+import (
+	"container/list"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/l3af-project/l3afd/config"
+	"github.com/l3af-project/l3afd/models"
+
+	"github.com/rs/zerolog/log"
+	"github.com/safchain/ethtool"
+)
+
+// DisableLRO - XDP programs are failing when LRO is enabled, to fix this we use to manually disable.
+// # ethtool -K ens7 lro off
+// # ethtool -k ens7 | grep large-receive-offload
+// large-receive-offload: off
+func DisableLRO(ifaceName string) error {
+	ethHandle, err := ethtool.NewEthtool()
+	if err != nil {
+		err = fmt.Errorf("ethtool failed to get the handle %w", err)
+		log.Error().Err(err).Msg("")
+		return err
+	}
+	defer ethHandle.Close()
+
+	config := make(map[string]bool, 1)
+	config["rx-lro"] = false
+	if err := ethHandle.Change(ifaceName, config); err != nil {
+		err = fmt.Errorf("ethtool failed to disable LRO on %s with err %w", ifaceName, err)
+		log.Error().Err(err).Msg("")
+		return err
+	}
+
+	return nil
+}
+
+// prLimit set the memory and cpu limits for the bpf program
+func prLimit(pid int, limit uintptr, rlimit *unix.Rlimit) error {
+	_, _, errno := unix.RawSyscall6(unix.SYS_PRLIMIT64,
+		uintptr(pid),
+		limit,
+		uintptr(unsafe.Pointer(rlimit)),
+		0, 0, 0)
+
+	if errno != 0 {
+		log.Error().Msgf("Failed to set prlimit for process %d and errorno %d", pid, errno)
+		return errors.New("Failed to set prlimit")
+	}
+
+	return nil
+}
+
+// Set process resource limits only non-zero value
+func (b *BPF) SetPrLimits() error {
+	var rlimit unix.Rlimit
+
+	if b.Cmd == nil {
+		return errors.New("No Process to set limits")
+	}
+
+	if b.Program.Memory != 0 {
+		rlimit.Cur = uint64(b.Program.Memory)
+		rlimit.Max = uint64(b.Program.Memory)
+
+		if err := prLimit(b.Cmd.Process.Pid, unix.RLIMIT_AS, &rlimit); err != nil {
+			log.Error().Err(err).Msgf("Failed to set Memory limits - %s", b.Program.Name)
+		}
+	}
+
+	if b.Program.CPU != 0 {
+		rlimit.Cur = uint64(b.Program.CPU)
+		rlimit.Max = uint64(b.Program.CPU)
+		if err := prLimit(b.Cmd.Process.Pid, unix.RLIMIT_CPU, &rlimit); err != nil {
+			log.Error().Err(err).Msgf("Failed to set CPU limits - %s", b.Program.Name)
+		}
+	}
+
+	return nil
+}

--- a/kf/kf_unix.go
+++ b/kf/kf_unix.go
@@ -91,3 +91,24 @@ func (b *BPF) SetPrLimits() error {
 
 	return nil
 }
+
+// VerifyNMountBPFFS - Mounting bpf filesystem
+func VerifyNMountBPFFS() error {
+	dstPath := "/sys/fs/bpf"
+	srcPath := "bpffs"
+	fstype := "bpf"
+	flags := 0
+
+	mnts, err := ioutil.ReadFile("/proc/mounts")
+	if err != nil {
+		return fmt.Errorf("failed to read procfs: %v", err)
+	}
+
+	if strings.Contains(string(mnts), dstPath) == false {
+		log.Warn().Msg("bpf filesystem is not mounted going to mount")
+		if err = syscall.Mount(srcPath, dstPath, fstype, uintptr(flags), ""); err != nil {
+			return fmt.Errorf("unable to mount %s at %s: %s", srcPath, dstPath, err)
+		}
+	}
+	return nil
+}

--- a/kf/kf_unix.go
+++ b/kf/kf_unix.go
@@ -112,3 +112,19 @@ func VerifyNMountBPFFS() error {
 	}
 	return nil
 }
+
+// This method get the Linux distribution Codename. This logic works on ubuntu
+// Here assumption is all edge nodes are running with lsb modules.
+// It returns empty string in case of error
+func GetPlatform() (string, error) {
+
+	linuxDistrib := execCommand("lsb_release", "-cs")
+	var out bytes.Buffer
+	linuxDistrib.Stdout = &out
+
+	if err := linuxDistrib.Run(); err != nil {
+		return "", fmt.Errorf("l3afd/nf : Failed to run command with error: %w", err)
+	}
+
+	return strings.TrimSpace(string(out.Bytes())), nil
+}

--- a/kf/kf_unix.go
+++ b/kf/kf_unix.go
@@ -128,3 +128,20 @@ func GetPlatform() (string, error) {
 
 	return strings.TrimSpace(string(out.Bytes())), nil
 }
+
+func IsProcessRunning(pid int, name string) (bool, string) {
+    procState, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+    if err != nil {
+        return false, fmt.Errorf("BPF Program not running %s because of error: %w", name, err)
+    }
+    var u1, u2, state string
+    _, err = fmt.Sscanf(string(procState), "%s %s %s", &u1, &u2, &state)
+    if err != nil {
+        return false, fmt.Errorf("Failed to scan proc state with error: %w", err)
+    }
+    if state == "Z" {
+        return false, fmt.Errorf("Process %d in Zombie state", pid)
+    }
+
+    return true, nil
+}

--- a/kf/kf_windows.go
+++ b/kf/kf_windows.go
@@ -6,9 +6,9 @@
 package kf
 
 import (
-    "errors"
-    "fmt"
-    "os"
+	"errors"
+	"fmt"
+	"os"
 )
 
 // DisableLRO - XDP programs are failing when Large Receive Offload is enabled, to fix this we use to manually disable.
@@ -18,9 +18,9 @@ func DisableLRO(ifaceName string) error {
 
 // Set process resource limits only non-zero value
 func (b *BPF) SetPrLimits() error {
-    if b.Cmd == nil {
-        return errors.New("No Process to set limits")
-    }
+	if b.Cmd == nil {
+		return errors.New("No Process to set limits")
+	}
 	return nil
 }
 
@@ -30,13 +30,13 @@ func VerifyNMountBPFFS() error {
 }
 
 func GetPlatform() (string, error) {
-    return "Windows", nil
+	return "Windows", nil
 }
 
 func IsProcessRunning(pid int, name string) (bool, error) {
-    _, err := os.FindProcess(pid)
-    if err != nil {
-        return false, fmt.Errorf("BPF Program not running %s because of error: %s", name, err)
-    }
-    return true, nil
+	_, err := os.FindProcess(pid)
+	if err != nil {
+		return false, fmt.Errorf("BPF Program not running %s because of error: %s", name, err)
+	}
+	return true, nil
 }

--- a/kf/kf_windows.go
+++ b/kf/kf_windows.go
@@ -19,3 +19,7 @@ func (b *BPF) SetPrLimits() error {
 func VerifyNMountBPFFS() error {
 	return nil
 }
+
+func GetPlatform() (string, error) {
+    return "Windows", nil
+}

--- a/kf/kf_windows.go
+++ b/kf/kf_windows.go
@@ -1,0 +1,16 @@
+// Copyright Contributors to the L3AF Project.
+// SPDX-License-Identifier: Apache-2.0
+// +build WINDOWS
+
+// Package kf provides primitives for l3afd's network function configs.
+package kf
+
+// DisableLRO - XDP programs are failing when Large Receive Offload is enabled, to fix this we use to manually disable.
+func DisableLRO(ifaceName string) error {
+	return nil
+}
+
+// Set process resource limits only non-zero value
+func (b *BPF) SetPrLimits() error {
+	return nil
+}

--- a/kf/kf_windows.go
+++ b/kf/kf_windows.go
@@ -14,3 +14,8 @@ func DisableLRO(ifaceName string) error {
 func (b *BPF) SetPrLimits() error {
 	return nil
 }
+
+// VerifyNMountBPFFS - Mounting bpf filesystem
+func VerifyNMountBPFFS() error {
+	return nil
+}

--- a/kf/kf_windows.go
+++ b/kf/kf_windows.go
@@ -5,6 +5,12 @@
 // Package kf provides primitives for l3afd's network function configs.
 package kf
 
+import (
+    "errors"
+    "fmt"
+    "os"
+)
+
 // DisableLRO - XDP programs are failing when Large Receive Offload is enabled, to fix this we use to manually disable.
 func DisableLRO(ifaceName string) error {
 	return nil
@@ -12,6 +18,9 @@ func DisableLRO(ifaceName string) error {
 
 // Set process resource limits only non-zero value
 func (b *BPF) SetPrLimits() error {
+    if b.Cmd == nil {
+        return errors.New("No Process to set limits")
+    }
 	return nil
 }
 
@@ -22,4 +31,12 @@ func VerifyNMountBPFFS() error {
 
 func GetPlatform() (string, error) {
     return "Windows", nil
+}
+
+func IsProcessRunning(pid int, name string) (bool, error) {
+    _, err := os.FindProcess(pid)
+    if err != nil {
+        return false, fmt.Errorf("BPF Program not running %s because of error: %s", name, err)
+    }
+    return true, nil
 }

--- a/kf/kfmetrics.go
+++ b/kf/kfmetrics.go
@@ -1,7 +1,7 @@
 // Copyright Contributors to the L3AF Project.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package nf provides primitives for NF process monitoring.
+// Package kf provides primitives for NF process monitoring.
 package kf
 
 import (

--- a/kf/nfconfig.go
+++ b/kf/nfconfig.go
@@ -9,11 +9,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/l3af-project/l3afd/config"
@@ -681,27 +679,6 @@ func (c *NFConfigs) StopRootProgram(ifaceName, direction string) error {
 		return fmt.Errorf("unknown direction type")
 	}
 
-	return nil
-}
-
-// VerifyNMountBPFFS - Mounting bpf filesystem
-func VerifyNMountBPFFS() error {
-	dstPath := "/sys/fs/bpf"
-	srcPath := "bpffs"
-	fstype := "bpf"
-	flags := 0
-
-	mnts, err := ioutil.ReadFile("/proc/mounts")
-	if err != nil {
-		return fmt.Errorf("failed to read procfs: %v", err)
-	}
-
-	if strings.Contains(string(mnts), dstPath) == false {
-		log.Warn().Msg("bpf filesystem is not mounted going to mount")
-		if err = syscall.Mount(srcPath, dstPath, fstype, uintptr(flags), ""); err != nil {
-			return fmt.Errorf("unable to mount %s at %s: %s", srcPath, dstPath, err)
-		}
-	}
 	return nil
 }
 

--- a/kf/nfconfig.go
+++ b/kf/nfconfig.go
@@ -20,7 +20,6 @@ import (
 	"github.com/l3af-project/l3afd/models"
 
 	"github.com/rs/zerolog/log"
-	"github.com/safchain/ethtool"
 )
 
 type NFConfigs struct {
@@ -855,29 +854,5 @@ func (c *NFConfigs) RemoveMissingNetIfacesNBPFProgsInConfigs(cfgbpfProgs map[str
 	}()
 
 	wg.Wait()
-	return nil
-}
-
-// DisableLRO - XDP programs are failing when LRO is enabled, to fix this we use to manually disable.
-// # ethtool -K ens7 lro off
-// # ethtool -k ens7 | grep large-receive-offload
-// large-receive-offload: off
-func DisableLRO(ifaceName string) error {
-	ethHandle, err := ethtool.NewEthtool()
-	if err != nil {
-		err = fmt.Errorf("ethtool failed to get the handle %w", err)
-		log.Error().Err(err).Msg("")
-		return err
-	}
-	defer ethHandle.Close()
-
-	config := make(map[string]bool, 1)
-	config["rx-lro"] = false
-	if err := ethHandle.Change(ifaceName, config); err != nil {
-		err = fmt.Errorf("ethtool failed to disable LRO on %s with err %w", ifaceName, err)
-		log.Error().Err(err).Msg("")
-		return err
-	}
-
 	return nil
 }

--- a/kf/processCheck.go
+++ b/kf/processCheck.go
@@ -1,7 +1,7 @@
 // Copyright Contributors to the L3AF Project.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package nf provides primitives for NF process monitoring.
+// Package kf provides primitives for NF process monitoring.
 package kf
 
 import (

--- a/pidfile/pidfile.go
+++ b/pidfile/pidfile.go
@@ -39,10 +39,14 @@ func CheckPIDConflict(pidFilename string) error {
 	}
 
 	log.Info().Msgf("Found PID file with PID: %s; checking if process is running...", oldPIDString)
-	//If sig is 0, then no signal is sent, but error checking is still performed;
-	//this can be used to check for the existence of a process ID or process  group ID.
-	//See: man 2 kill
-	if err = syscall.Kill(oldPID, 0); err != nil {
+	process, err := os.FindProcess(oldPID)
+	if err == nil {
+	    //On Linux, if sig is 0, then no signal is sent, but error checking is still performed;
+	    //this can be used to check for the existence of a process ID or process  group ID.
+	    //See: man 2 kill
+	    err = process.Signal(syscall.Signal(0))
+	}
+	if err != nil {
 		log.Info().Msgf("Process was not running, removing PID file.")
 		if err = RemovePID(pidFilename); err != nil {
 			return fmt.Errorf("Removal failed, please manually remove; err: %v", err)


### PR DESCRIPTION
This PR:
* Updates some code from Linux-only calls to cross-platform calls
* For code that I could not find a simple cross-platform call, moved Linux-only code to *_unix.go file and Windows-only code to *_windows.go to create a platform abstraction layer with the same methods implemented (differently) in different files.
* Renamed the LinuxDistribution() function to the more cross-platform-friendly GetPlatform()
* Updated the tests as well
* Added a ci-build-windows.yaml file to the github workflow to test building on windows
* Updated README.md file to fix #11 by documenting what the github workflow does.

This PR does not actually test any actual eBPF functionality, since the ci-build.yaml file didn't either.   That should be done by adding cross-platform tests, since it already runs "go test ./..." on Windows which passes as long as you pass "-tags WINDOWS" to tell it to use the windows implementation instead of the linux implementation under the platform abstraction layer.