### PR TITLE
Remove Karan

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default Code Owners
 
-* @sanfern @satyaranjanp @jniesz @dalalkaran
+* @sanfern @satyaranjanp @jniesz


### PR DESCRIPTION
He's moving on up! Unfortunately, this means he won't be as involved with L3AF and therefore shouldn't be in CODEOWNERS. Otherwise he unintentionally becomes a blocker for reviews.