### PR TITLE
Add dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Copyright Contributors to the L3AF Project.
+# SPDX-License-Identifier: Apache-2.0
+#
+# For documentation on the format of this file, see
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    # Workflow files are stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
Dependabot will automatically file a pull request when there is
a newer version of a dependency available.  The principle is
that l3afd should always upgrade to use the latest release of each dependency
whenever possible to get bug fixes and security patches.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>