### PR TITLE
add rules for generating release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# .github/release.yml
+---
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 💥
+      labels:
+        - breaking-change
+        - breaking
+    - title: New Features 🎉
+      labels:
+        - feat
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - fix
+        - bugfix
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This PR is to make it easier to generate and categorize release notes for l3afd based on labels defined in PRs.

More info on this features is defined below.
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
