### PR TITLE
Fix pid file logging

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# .github/release.yml
+---
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 💥
+      labels:
+        - breaking-change
+        - breaking
+    - title: New Features 🎉
+      labels:
+        - feat
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - fix
+        - bugfix
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/pidfile/pidfile.go
+++ b/pidfile/pidfile.go
@@ -20,7 +20,7 @@ func CheckPIDConflict(pidFilename string) error {
 	pidFileContent, err := ioutil.ReadFile(pidFilename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Error().Msgf("OK, no PID file already exists at %s.", pidFilename)
+			log.Info().Msgf("OK, no PID file already exists at %s.", pidFilename)
 			return nil
 		}
 		return fmt.Errorf("could not open PID file: %s, please manually remove; error: %v", pidFilename, err)


### PR DESCRIPTION
If there is no pid that exists we should just log this as info instead of an error as this is normal on start up.