### PR TITLE
fix installing of swag binary on newer versions of go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@ all: swagger build
 
 swagger:
 	@mkdir $(GOPATH) || true 
-	@go get -u github.com/swaggo/swag/cmd/swag
-	@go get -u github.com/swaggo/http-swagger
-	@go get -u github.com/alecthomas/template
+	@go install github.com/swaggo/swag/cmd/swag@latest
 	@$(GOPATH)/bin/swag init -d "./" -g "apis/configwatch.go"
 
 build:


### PR DESCRIPTION
`go get -u github.com/swaggo/swag/cmd/swag fails` on newer versions of go and go install should be used instead.

Signed-off-by: Jason Niesz <Jason.Niesz@walmart.com>