### PR TITLE
Add github-repo-stats workflow file

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -1,0 +1,19 @@
+name: github-repo-stats
+
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  j1:
+    name: github-repo-stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        # Use latest release.
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          ghtoken: ${{ secrets.ghrs_github_api_token }}

--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - name: run-ghrs
         # Use latest release.
-      - name: github-repo-stats
         uses: jgehrcke/github-repo-stats@v1.4.1
         with:
           ghtoken: ${{ secrets.ghrs_github_api_token }}

--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: run-ghrs
         # Use latest release.
-        uses: jgehrcke/github-repo-stats@RELEASE
+      - name: github-repo-stats
+        uses: jgehrcke/github-repo-stats@v1.4.1
         with:
           ghtoken: ${{ secrets.ghrs_github_api_token }}


### PR DESCRIPTION
Signed-off-by: Charles Liu <charles.liu0@walmart.com>

This PR is to use gihub-repo-stats to create stats history for l3afd repo over 14 days limit.