### PR TITLE
feat: introduce interface name to NFMonitorMap

### DIFF
--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -840,7 +840,7 @@ func (b *BPF) MonitorMaps(ifaceName string, intervals int) error {
 		}
 		bpfMap := b.MetricsBpfMaps[mapKey]
 		MetricName := element.Name + "_" + strconv.Itoa(element.Key) + "_" + element.Aggregator
-		stats.SetValue(bpfMap.GetValue(), stats.NFMonitorMap, b.Program.Name, MetricName, ifaceName)
+		stats.SetValue(bpfMap.GetValue(), stats.NFMonitorMap, b.Program.Name, MetricName)
 	}
 	return nil
 }

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -840,7 +840,7 @@ func (b *BPF) MonitorMaps(ifaceName string, intervals int) error {
 		}
 		bpfMap := b.MetricsBpfMaps[mapKey]
 		MetricName := element.Name + "_" + strconv.Itoa(element.Key) + "_" + element.Aggregator
-		stats.SetValue(bpfMap.GetValue(), stats.NFMointorMap, b.Program.Name, MetricName)
+		stats.SetValue(bpfMap.GetValue(), stats.NFMonitorMap, b.Program.Name, MetricName, ifaceName)
 	}
 	return nil
 }

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -237,10 +237,10 @@ func (b *BPF) Stop(ifaceName, direction string, chain bool) error {
 	// Reset ProgID
 	b.ProgID = 0
 
-	stats.Incr(stats.NFStopCount, b.Program.Name, direction)
+	stats.Incr(stats.NFStopCount, b.Program.Name, direction, "")
 
 	// Setting NFRunning to 0, indicates not running
-	stats.Set(0.0, stats.NFRunning, b.Program.Name, direction)
+	stats.Set(0.0, stats.NFRunning, b.Program.Name, direction, "")
 
 	if len(b.Program.CmdStop) < 1 {
 		if err := b.ProcessTerminate(); err != nil {
@@ -434,8 +434,8 @@ func (b *BPF) Start(ifaceName, direction string, chain bool) error {
 	if err := b.SetPrLimits(); err != nil {
 		log.Warn().Err(err).Msg("failed to set resource limits")
 	}
-	stats.Incr(stats.NFStartCount, b.Program.Name, direction)
-	stats.Set(float64(time.Now().Unix()), stats.NFStartTime, b.Program.Name, direction)
+	stats.Incr(stats.NFStartCount, b.Program.Name, direction, "")
+	stats.Set(float64(time.Now().Unix()), stats.NFStartTime, b.Program.Name, direction, "")
 
 	log.Info().Msgf("BPF program - %s started Process id %d Program ID %d", b.Program.Name, b.Cmd.Process.Pid, b.ProgID)
 	return nil
@@ -462,7 +462,7 @@ func (b *BPF) Update(ifaceName, direction string) error {
 			bpfMap.Update(v)
 		}
 	}
-	stats.Incr(stats.NFUpdateCount, b.Program.Name, direction)
+	stats.Incr(stats.NFUpdateCount, b.Program.Name, direction, "")
 	return nil
 }
 
@@ -840,7 +840,7 @@ func (b *BPF) MonitorMaps(ifaceName string, intervals int) error {
 		}
 		bpfMap := b.MetricsBpfMaps[mapKey]
 		MetricName := element.Name + "_" + strconv.Itoa(element.Key) + "_" + element.Aggregator
-		stats.SetValue(bpfMap.GetValue(), stats.NFMonitorMap, b.Program.Name, MetricName)
+		stats.SetValue(bpfMap.GetValue(), stats.NFMonitorMap, b.Program.Name, MetricName, "")
 	}
 	return nil
 }

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -237,10 +237,10 @@ func (b *BPF) Stop(ifaceName, direction string, chain bool) error {
 	// Reset ProgID
 	b.ProgID = 0
 
-	stats.Incr(stats.NFStopCount, b.Program.Name, direction, "")
+	stats.Incr(stats.NFStopCount, b.Program.Name, direction, ifaceName)
 
 	// Setting NFRunning to 0, indicates not running
-	stats.Set(0.0, stats.NFRunning, b.Program.Name, direction, "")
+	stats.Set(0.0, stats.NFRunning, b.Program.Name, direction, ifaceName)
 
 	if len(b.Program.CmdStop) < 1 {
 		if err := b.ProcessTerminate(); err != nil {
@@ -434,8 +434,8 @@ func (b *BPF) Start(ifaceName, direction string, chain bool) error {
 	if err := b.SetPrLimits(); err != nil {
 		log.Warn().Err(err).Msg("failed to set resource limits")
 	}
-	stats.Incr(stats.NFStartCount, b.Program.Name, direction, "")
-	stats.Set(float64(time.Now().Unix()), stats.NFStartTime, b.Program.Name, direction, "")
+	stats.Incr(stats.NFStartCount, b.Program.Name, direction, ifaceName)
+	stats.Set(float64(time.Now().Unix()), stats.NFStartTime, b.Program.Name, direction, ifaceName)
 
 	log.Info().Msgf("BPF program - %s started Process id %d Program ID %d", b.Program.Name, b.Cmd.Process.Pid, b.ProgID)
 	return nil
@@ -462,7 +462,7 @@ func (b *BPF) Update(ifaceName, direction string) error {
 			bpfMap.Update(v)
 		}
 	}
-	stats.Incr(stats.NFUpdateCount, b.Program.Name, direction, "")
+	stats.Incr(stats.NFUpdateCount, b.Program.Name, direction, ifaceName)
 	return nil
 }
 
@@ -840,7 +840,7 @@ func (b *BPF) MonitorMaps(ifaceName string, intervals int) error {
 		}
 		bpfMap := b.MetricsBpfMaps[mapKey]
 		MetricName := element.Name + "_" + strconv.Itoa(element.Key) + "_" + element.Aggregator
-		stats.SetValue(bpfMap.GetValue(), stats.NFMonitorMap, b.Program.Name, MetricName, "")
+		stats.SetValue(bpfMap.GetValue(), stats.NFMonitorMap, b.Program.Name, MetricName, ifaceName)
 	}
 	return nil
 }

--- a/kf/processCheck.go
+++ b/kf/processCheck.go
@@ -51,7 +51,7 @@ func (c *pCheck) pMonitorWorker(bpfProgs map[string]*list.List, direction string
 				}
 				isRunning, _ := bpf.isRunning()
 				if isRunning {
-					stats.Set(1.0, stats.NFRunning, bpf.Program.Name, direction, "")
+					stats.Set(1.0, stats.NFRunning, bpf.Program.Name, direction, ifaceName)
 					continue
 				}
 				// Not running trying to restart
@@ -63,7 +63,7 @@ func (c *pCheck) pMonitorWorker(bpfProgs map[string]*list.List, direction string
 						log.Error().Err(err).Msgf("pMonitor BPF Program start failed for program %s", bpf.Program.Name)
 					}
 				} else {
-					stats.Set(0.0, stats.NFRunning, bpf.Program.Name, direction, "")
+					stats.Set(0.0, stats.NFRunning, bpf.Program.Name, direction, ifaceName)
 				}
 			}
 		}

--- a/kf/processCheck.go
+++ b/kf/processCheck.go
@@ -51,7 +51,7 @@ func (c *pCheck) pMonitorWorker(bpfProgs map[string]*list.List, direction string
 				}
 				isRunning, _ := bpf.isRunning()
 				if isRunning {
-					stats.Set(1.0, stats.NFRunning, bpf.Program.Name, direction)
+					stats.Set(1.0, stats.NFRunning, bpf.Program.Name, direction, "")
 					continue
 				}
 				// Not running trying to restart
@@ -63,7 +63,7 @@ func (c *pCheck) pMonitorWorker(bpfProgs map[string]*list.List, direction string
 						log.Error().Err(err).Msgf("pMonitor BPF Program start failed for program %s", bpf.Program.Name)
 					}
 				} else {
-					stats.Set(0.0, stats.NFRunning, bpf.Program.Name, direction)
+					stats.Set(0.0, stats.NFRunning, bpf.Program.Name, direction, "")
 				}
 			}
 		}

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -29,7 +29,7 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 			Name:      "NFStartCount",
 			Help:      "The count of network functions started",
 		},
-		[]string{"host", "network_function", "direction"},
+		[]string{"host", "ebpf_program", "direction", "interface_name"},
 	)
 
 	NFStartCount = nfStartCountVec.MustCurryWith(prometheus.Labels{"host": hostname})
@@ -40,7 +40,7 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 			Name:      "NFStopCount",
 			Help:      "The count of network functions stopped",
 		},
-		[]string{"host", "network_function", "direction"},
+		[]string{"host", "ebpf_program", "direction", "interface_name"},
 	)
 
 	NFStopCount = nfStopCountVec.MustCurryWith(prometheus.Labels{"host": hostname})
@@ -51,7 +51,7 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 			Name:      "NFUpdateCount",
 			Help:      "The count of network functions updated",
 		},
-		[]string{"host", "network_function", "direction"},
+		[]string{"host", "ebpf_program", "direction", "interface_name"},
 	)
 
 	NFUpdateCount = nfUpdateCountVec.MustCurryWith(prometheus.Labels{"host": hostname})
@@ -62,7 +62,7 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 			Name:      "NFRunning",
 			Help:      "This value indicates network functions is running or not",
 		},
-		[]string{"host", "network_function", "direction"},
+		[]string{"host", "ebpf_program", "direction", "interface_name"},
 	)
 
 	if err := prometheus.Register(nfRunningVec); err != nil {
@@ -77,7 +77,7 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 			Name:      "NFStartTime",
 			Help:      "This value indicates start time of the network function since unix epoch in seconds",
 		},
-		[]string{"host", "network_function", "direction"},
+		[]string{"host", "ebpf_program", "direction", "interface_name"},
 	)
 
 	if err := prometheus.Register(nfStartTimeVec); err != nil {
@@ -114,29 +114,63 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 	}()
 }
 
-func Incr(counterVec *prometheus.CounterVec, networkFunction, direction string) {
+func Incr(counterVec *prometheus.CounterVec, ebpfProgram, direction string) {
 
 	if counterVec == nil {
 		log.Warn().Msg("Metrics: counter vector is nil and needs to be initialized before Incr")
 		return
 	}
-	if nfCounter, err := counterVec.GetMetricWithLabelValues(networkFunction, direction); err == nil {
+	if nfCounter, err := counterVec.GetMetricWithLabelValues(ebpfProgram, direction); err == nil {
 		nfCounter.Inc()
 	}
 }
 
-func Set(value float64, gaugeVec *prometheus.GaugeVec, networkFunction, direction string) {
+func IncrWithInterface(counterVec *prometheus.CounterVec, ebpfProgram, direction, ifaceName string) {
+
+	if counterVec == nil {
+		log.Warn().Msg("Metrics: counter vector is nil and needs to be initialized before Incr")
+		return
+	}
+	if nfCounter, err := counterVec.GetMetricWithLabelValues(ebpfProgram, direction, ifaceName); err == nil {
+		nfCounter.Inc()
+	}
+
+}
+
+func Set(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, direction string) {
 
 	if gaugeVec == nil {
 		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before Set")
 		return
 	}
-	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(networkFunction, direction); err == nil {
+	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(ebpfProgram, direction); err == nil {
 		nfGauge.Set(value)
 	}
 }
 
-func SetValue(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName, ifaceName string) {
+func SetWithInterface(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, direction, ifaceName string) {
+
+	if gaugeVec == nil {
+		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before Set")
+		return
+	}
+	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(ebpfProgram, direction, ifaceName); err == nil {
+		nfGauge.Set(value)
+	}
+}
+
+func SetValue(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName string) {
+
+	if gaugeVec == nil {
+		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before SetValue")
+		return
+	}
+	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(ebpfProgram, mapName); err == nil {
+		nfGauge.Set(value)
+	}
+}
+
+func SetValueWithInterface(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName, ifaceName string) {
 
 	if gaugeVec == nil {
 		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before SetValue")

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -18,7 +18,7 @@ var (
 	NFUpdateCount *prometheus.CounterVec
 	NFRunning     *prometheus.GaugeVec
 	NFStartTime   *prometheus.GaugeVec
-	NFMointorMap  *prometheus.GaugeVec
+	NFMonitorMap  *prometheus.GaugeVec
 )
 
 func SetupMetrics(hostname, daemonName, metricsAddr string) {
@@ -92,14 +92,14 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 			Name:      "NFMonitorMap",
 			Help:      "This value indicates network function monitor counters",
 		},
-		[]string{"host", "network_function", "map_name"},
+		[]string{"host", "ebpf_program", "map_name", "interface_name"},
 	)
 
 	if err := prometheus.Register(nfMonitorMapVec); err != nil {
 		log.Warn().Err(err).Msg("Failed to register NFMonitorMap metrics")
 	}
 
-	NFMointorMap = nfMonitorMapVec.MustCurryWith(prometheus.Labels{"host": hostname})
+	NFMonitorMap = nfMonitorMapVec.MustCurryWith(prometheus.Labels{"host": hostname})
 
 	// Prometheus handler
 	metricsHandler := promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{})
@@ -136,13 +136,13 @@ func Set(value float64, gaugeVec *prometheus.GaugeVec, networkFunction, directio
 	}
 }
 
-func SetValue(value float64, gaugeVec *prometheus.GaugeVec, networkFunction, mapName string) {
+func SetValue(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName, ifaceName string) {
 
 	if gaugeVec == nil {
 		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before SetValue")
 		return
 	}
-	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(networkFunction, mapName); err == nil {
+	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(ebpfProgram, mapName, ifaceName); err == nil {
 		nfGauge.Set(value)
 	}
 }

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -114,69 +114,65 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 	}()
 }
 
-func Incr(counterVec *prometheus.CounterVec, ebpfProgram, direction string) {
+func Incr(counterVec *prometheus.CounterVec, ebpfProgram, direction, ifaceName string) {
 
 	if counterVec == nil {
 		log.Warn().Msg("Metrics: counter vector is nil and needs to be initialized before Incr")
 		return
 	}
-	if nfCounter, err := counterVec.GetMetricWithLabelValues(ebpfProgram, direction); err == nil {
-		nfCounter.Inc()
-	}
-}
-
-func IncrWithInterface(counterVec *prometheus.CounterVec, ebpfProgram, direction, ifaceName string) {
-
-	if counterVec == nil {
-		log.Warn().Msg("Metrics: counter vector is nil and needs to be initialized before Incr")
+	nfCounter, err := counterVec.GetMetricWith(
+		prometheus.Labels(map[string]string{
+			"ebpf_program":   ebpfProgram,
+			"direction":      direction,
+			"interface_name": ifaceName,
+		}),
+	)
+	if err != nil {
+		log.Warn().Msgf("Metrics: unable to fetch counter with fields: ebpf_program: %s, direction: %s, interface_name: %s",
+			ebpfProgram, direction, ifaceName)
 		return
 	}
-	if nfCounter, err := counterVec.GetMetricWithLabelValues(ebpfProgram, direction, ifaceName); err == nil {
-		nfCounter.Inc()
-	}
-
+	nfCounter.Inc()
 }
 
-func Set(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, direction string) {
+func Set(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, direction, ifaceName string) {
 
 	if gaugeVec == nil {
 		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before Set")
 		return
 	}
-	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(ebpfProgram, direction); err == nil {
-		nfGauge.Set(value)
-	}
-}
-
-func SetWithInterface(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, direction, ifaceName string) {
-
-	if gaugeVec == nil {
-		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before Set")
+	nfGauge, err := gaugeVec.GetMetricWith(
+		prometheus.Labels(map[string]string{
+			"ebpf_program":   ebpfProgram,
+			"direction":      direction,
+			"interface_name": ifaceName,
+		}),
+	)
+	if err != nil {
+		log.Warn().Msgf("Metrics: unable to fetch counter with fields: ebpf_program: %s, direction: %s, interface_name: %s",
+			ebpfProgram, direction, ifaceName)
 		return
 	}
-	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(ebpfProgram, direction, ifaceName); err == nil {
-		nfGauge.Set(value)
-	}
+	nfGauge.Set(value)
 }
 
-func SetValue(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName string) {
-
-	if gaugeVec == nil {
-		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before SetValue")
-		return
-	}
-	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(ebpfProgram, mapName); err == nil {
-		nfGauge.Set(value)
-	}
-}
-
-func SetValueWithInterface(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName, ifaceName string) {
+func SetValue(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName, ifaceName string) {
 
 	if gaugeVec == nil {
 		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before SetValue")
 		return
 	}
-	if nfGauge, err := gaugeVec.GetMetricWithLabelValues(ebpfProgram, mapName, ifaceName); err == nil {
-		nfGauge.Set(value)
+	nfGauge, err := gaugeVec.GetMetricWith(
+		prometheus.Labels(map[string]string{
+			"ebpf_program":   ebpfProgram,
+			"map_name":       mapName,
+			"interface_name": ifaceName,
+		}),
+	)
+	if err != nil {
+		log.Warn().Msgf("Metrics: unable to fetch counter with fields: ebpf_program: %s, map_name: %s, interface_name: %s",
+			ebpfProgram, mapName, ifaceName)
+		return
 	}
+	nfGauge.Set(value)
 }


### PR DESCRIPTION
This diff introduces an `interface_name` field to `NFMonitorMap` and renames `network_function` to `ebpf_program`.
Closes #201 