### PR TITLE
feat: introduce error handling to kfdebug

### DIFF
--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -58,8 +58,8 @@ type BPF struct {
 	ProgID          int                       // eBPF Program ID
 	BpfMaps         map[string]BPFMap         // Config maps passed as map-args, Map name is Key
 	MetricsBpfMaps  map[string]*MetricsBPFMap // Metrics map name+key+aggregator is key
-	Ctx             context.Context
-	Done            chan bool `json:"-"`
+	Ctx             context.Context           `json:"-"`
+	Done            chan bool                 `json:"-"`
 	hostConfig      *config.Config
 }
 

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -50,7 +50,7 @@ const fileScheme string = "file"
 // BPF defines run time details for BPFProgram.
 type BPF struct {
 	Program         models.BPFProgram
-	Cmd             *exec.Cmd
+	Cmd             *exec.Cmd                 `json:"-"`
 	FilePath        string                    // Binary file path
 	RestartCount    int                       // To track restart count
 	PrevMapNamePath string                    // Previous Map name with path to link

--- a/kf/kfdebug.go
+++ b/kf/kfdebug.go
@@ -31,5 +31,7 @@ func ViewHandler(w http.ResponseWriter, r *http.Request) {
 	iface := strings.TrimPrefix(r.URL.Path, "/kfs/")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(kfcfgs.KFDetails(iface))
+	if err := json.NewEncoder(w).Encode(kfcfgs.KFDetails(iface)); err != nil {
+		log.Err(err).Msgf("unable to serialize json")
+	}
 }


### PR DESCRIPTION
This diff introduces error handling to the JSON serialization method in `/kf/kfdebug.go`. It also solves #213 by deactivating `*exe.Cmd` in the JSON response (due to which we had the empty response in the first place).