### PR TITLE
feat: introduce version tag to NFRunning metric

### DIFF
--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -240,7 +240,7 @@ func (b *BPF) Stop(ifaceName, direction string, chain bool) error {
 	stats.Incr(stats.NFStopCount, b.Program.Name, direction, ifaceName)
 
 	// Setting NFRunning to 0, indicates not running
-	stats.Set(0.0, stats.NFRunning, b.Program.Name, direction, ifaceName)
+	stats.SetWithVersion(0.0, stats.NFRunning, b.Program.Name, b.Program.Version, direction, ifaceName)
 
 	if len(b.Program.CmdStop) < 1 {
 		if err := b.ProcessTerminate(); err != nil {

--- a/kf/processCheck.go
+++ b/kf/processCheck.go
@@ -51,7 +51,7 @@ func (c *pCheck) pMonitorWorker(bpfProgs map[string]*list.List, direction string
 				}
 				isRunning, _ := bpf.isRunning()
 				if isRunning {
-					stats.Set(1.0, stats.NFRunning, bpf.Program.Name, direction, ifaceName)
+					stats.SetWithVersion(1.0, stats.NFRunning, bpf.Program.Name, bpf.Program.Version, direction, ifaceName)
 					continue
 				}
 				// Not running trying to restart
@@ -63,7 +63,7 @@ func (c *pCheck) pMonitorWorker(bpfProgs map[string]*list.List, direction string
 						log.Error().Err(err).Msgf("pMonitor BPF Program start failed for program %s", bpf.Program.Name)
 					}
 				} else {
-					stats.Set(0.0, stats.NFRunning, bpf.Program.Name, direction, ifaceName)
+					stats.SetWithVersion(0.0, stats.NFRunning, bpf.Program.Name, bpf.Program.Version, direction, ifaceName)
 				}
 			}
 		}

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -192,8 +192,8 @@ func SetWithVersion(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, v
 		}),
 	)
 	if err != nil {
-		log.Warn().Msgf("Metrics: unable to fetch gauge with fields: ebpf_program: %s, direction: %s, interface_name: %s",
-			ebpfProgram, direction, ifaceName)
+		log.Warn().Msgf("Metrics: unable to fetch gauge with fields: ebpf_program: %s, version: %s, direction: %s, interface_name: %s",
+			ebpfProgram, version, direction, ifaceName)
 		return
 	}
 	nfGauge.Set(value)

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -62,7 +62,7 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 			Name:      "NFRunning",
 			Help:      "This value indicates network functions is running or not",
 		},
-		[]string{"host", "ebpf_program", "direction", "interface_name"},
+		[]string{"host", "ebpf_program", "version", "direction", "interface_name"},
 	)
 
 	if err := prometheus.Register(nfRunningVec); err != nil {
@@ -149,7 +149,7 @@ func Set(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, direction, i
 		}),
 	)
 	if err != nil {
-		log.Warn().Msgf("Metrics: unable to fetch counter with fields: ebpf_program: %s, direction: %s, interface_name: %s",
+		log.Warn().Msgf("Metrics: unable to fetch gauge with fields: ebpf_program: %s, direction: %s, interface_name: %s",
 			ebpfProgram, direction, ifaceName)
 		return
 	}
@@ -170,8 +170,30 @@ func SetValue(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName
 		}),
 	)
 	if err != nil {
-		log.Warn().Msgf("Metrics: unable to fetch counter with fields: ebpf_program: %s, map_name: %s, interface_name: %s",
+		log.Warn().Msgf("Metrics: unable to fetch gauge with fields: ebpf_program: %s, map_name: %s, interface_name: %s",
 			ebpfProgram, mapName, ifaceName)
+		return
+	}
+	nfGauge.Set(value)
+}
+
+func SetWithVersion(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, version, direction, ifaceName string) {
+
+	if gaugeVec == nil {
+		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before Set")
+		return
+	}
+	nfGauge, err := gaugeVec.GetMetricWith(
+		prometheus.Labels(map[string]string{
+			"ebpf_program":   ebpfProgram,
+			"version":        version,
+			"direction":      direction,
+			"interface_name": ifaceName,
+		}),
+	)
+	if err != nil {
+		log.Warn().Msgf("Metrics: unable to fetch gauge with fields: ebpf_program: %s, direction: %s, interface_name: %s",
+			ebpfProgram, direction, ifaceName)
 		return
 	}
 	nfGauge.Set(value)


### PR DESCRIPTION
This diff introduces a new `version` tag to the `l3afd_NFRunning` metric. 
Closes #221 