### PR TITLE
[WIP] feat: improve unit testing mechanism

### DIFF
--- a/apis/handlers/getconfig_test.go
+++ b/apis/handlers/getconfig_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"container/list"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +8,7 @@ import (
 
 	chi "github.com/go-chi/chi/v5"
 	"github.com/l3af-project/l3afd/kf"
+	"github.com/l3af-project/l3afd/list"
 )
 
 func Test_GetConfig(t *testing.T) {

--- a/kf/kfmetrics.go
+++ b/kf/kfmetrics.go
@@ -5,9 +5,9 @@
 package kf
 
 import (
-	"container/list"
 	"time"
 
+	"github.com/l3af-project/l3afd/list"
 	"github.com/l3af-project/l3afd/models"
 
 	"github.com/rs/zerolog/log"

--- a/kf/kfmetrics_test.go
+++ b/kf/kfmetrics_test.go
@@ -4,9 +4,10 @@
 package kf
 
 import (
-	"container/list"
 	"reflect"
 	"testing"
+
+	"github.com/l3af-project/l3afd/list"
 )
 
 func TestNewpKFMetrics(t *testing.T) {

--- a/kf/nfconfig_test.go
+++ b/kf/nfconfig_test.go
@@ -4,8 +4,8 @@
 package kf
 
 import (
-	"container/list"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/l3af-project/l3afd/config"
+	"github.com/l3af-project/l3afd/list"
+	"github.com/l3af-project/l3afd/mocks"
 	"github.com/l3af-project/l3afd/models"
 
 	"github.com/rs/zerolog/log"
@@ -127,6 +129,68 @@ func setupBPFProgramStatusChange() {
 	}
 	bpfProgsTmp.XDPIngress = append(bpfProgsTmp.XDPIngress, bpfProg)
 	valStatusChange = bpfProgsTmp
+}
+
+func setupValidBPFList(progName string) *list.List {
+	l := list.New()
+	bpf := &mocks.BPF{
+		MockName: func() string {
+			return progName
+		},
+		MockStop: func(ifaceName, direction string, chain bool) error {
+			return nil
+		},
+		MockUpdateAdminStatus: func(value string) {
+			// do nothing
+		},
+	}
+	l.PushBack(bpf)
+	l.PushBack(bpf)
+	return l
+}
+
+func setupBPFListsWithStopError(progName string) *list.List {
+	l := list.New()
+	l.PushBack(&mocks.BPF{
+		MockName: func() string {
+			return progName
+		},
+		MockStop: func(ifaceName, direction string, chain bool) error {
+			return errStopFailure
+		},
+		MockUpdateAdminStatus: func(value string) {
+			// do nothing
+		},
+	})
+	return l
+}
+
+func setupBPFListsWithPutError(progName string) *list.List {
+	l := list.New()
+	bpf := &mocks.BPF{
+		MockName: func() string {
+			return progName
+		},
+		MockStop: func(ifaceName, direction string, chain bool) error {
+			return nil
+		},
+		MockUpdateAdminStatus: func(value string) {
+			// do nothing
+		},
+		MockProgId: func() int {
+			return 0
+		},
+		MockPutNextProgFDFromID: func(progsID int) error {
+			return errUpdateFdFailure
+		},
+		MockMapNamePth: func() string {
+			return ""
+		},
+	}
+	l.PushBack(bpf)
+	l.PushBack(bpf)
+	l.PushBack(bpf)
+	return l
 }
 
 func TestNewNFConfigs(t *testing.T) {
@@ -555,7 +619,7 @@ func Test_AddProgramsOnInterface(t *testing.T) {
 				hostInterfaces: tt.field.hostInterfaces,
 				mu:             tt.field.mu,
 			}
-			err := cfg.AddProgramsOnInterface(tt.arg.iface, tt.arg.hostName, tt.arg.bpfProgs)
+			err := cfg.addProgramsOnInterface(tt.arg.iface, tt.arg.hostName, tt.arg.bpfProgs)
 			if (err != nil) != tt.wanterr {
 				t.Errorf("AddProgramsOnInterface: %v", err)
 			}
@@ -723,16 +787,18 @@ func TestDeleteProgramsOnInterface(t *testing.T) {
 		bpfProgs *models.BPFProgramNames
 	}
 	tests := []struct {
-		name    string
-		field   fields
-		arg     args
-		wanterr bool
+		name  string
+		field fields
+		arg   args
+		want  error
 	}{
 		{
-			name:    "UnknownHostName",
-			field:   fields{},
-			arg:     args{},
-			wanterr: true,
+			name:  "UnknownHostName",
+			field: fields{},
+			arg: args{
+				hostName: "l3af-local-test",
+			},
+			want: errUnknownHostName,
 		},
 		{
 			name: "NilInterface",
@@ -740,9 +806,22 @@ func TestDeleteProgramsOnInterface(t *testing.T) {
 				hostName: "l3af-local-test",
 			},
 			arg: args{
-				hostName: "fakeif0",
+				hostName: "l3af-local-test",
+				iface:    "",
 			},
-			wanterr: true,
+			want: errEmptyParameter,
+		},
+		{
+			name: "NilBPFProgs",
+			field: fields{
+				hostName: "l3af-local-test",
+			},
+			arg: args{
+				hostName: "l3af-local-test",
+				iface:    "dummyinterface",
+				bpfProgs: nil,
+			},
+			want: errEmptyParameter,
 		},
 		{
 			name: "UnknownInterface",
@@ -758,7 +837,34 @@ func TestDeleteProgramsOnInterface(t *testing.T) {
 					TCEgress:   []string{},
 				},
 			},
-			wanterr: true,
+			want: errUnknownInterface,
+		},
+		{
+			name: "BadInput",
+			field: fields{
+				hostName:       "l3af-local-test",
+				hostInterfaces: map[string]bool{"fakeif0": true},
+				mu:             new(sync.Mutex),
+				ingressXDPBpfs: map[string]*list.List{
+					"fakeif0": setupBPFListsWithStopError("ratelimiting"),
+				},
+				ingressTCBpfs: map[string]*list.List{"fakeif0": nil},
+				egressTCBpfs:  map[string]*list.List{"fakeif0": nil},
+				hostConfig: &config.Config{
+					BPFLogDir:  "",
+					DataCenter: "localdc",
+				},
+			},
+			arg: args{
+				hostName: "l3af-local-test",
+				iface:    "fakeif0",
+				bpfProgs: &models.BPFProgramNames{
+					XDPIngress: []string{"ratelimiting"},
+					TCIngress:  []string{},
+					TCEgress:   []string{},
+				},
+			},
+			want: errStopFailure,
 		},
 		{
 			name: "GoodInput",
@@ -779,7 +885,7 @@ func TestDeleteProgramsOnInterface(t *testing.T) {
 					TCEgress:   []string{},
 				},
 			},
-			wanterr: false,
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -794,12 +900,223 @@ func TestDeleteProgramsOnInterface(t *testing.T) {
 				hostInterfaces: tt.field.hostInterfaces,
 				mu:             tt.field.mu,
 			}
-			err := cfg.DeleteProgramsOnInterface(tt.arg.iface, tt.arg.hostName, tt.arg.bpfProgs)
-			if (err != nil) != tt.wanterr {
+			err := cfg.deleteProgramsOnInterface(tt.arg.iface, tt.arg.hostName, tt.arg.bpfProgs)
+			if !errors.Is(err, tt.want) {
 				t.Errorf("DeleteProgramsOnInterface failed: %v", err)
 			}
 		})
 	}
+}
+
+func TestDeleteProgramsByHook(t *testing.T) {
+	type args struct {
+		iface     string
+		direction string
+		progMap   map[string]*list.List
+		bpfProgs  []string
+	}
+	tests := []struct {
+		name string
+		arg  args
+		want error
+	}{
+		{
+			name: "NilProgMap",
+			arg: args{
+				progMap: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "UnkownInterface",
+			arg: args{
+				iface: "fakeif0",
+			},
+			want: nil,
+		},
+		{
+			name: "NilBPFList",
+			arg: args{
+				iface:   "fakeif0",
+				progMap: map[string]*list.List{"fakeif0": nil},
+			},
+			want: nil,
+		},
+		{
+			name: "UnknownBPFProgs",
+			arg: args{
+				iface: "fakeif0",
+				progMap: map[string]*list.List{
+					"fakeif0": setupBPFListsWithStopError("ratelimiting"),
+				},
+				bpfProgs: []string{"random"},
+			},
+			want: nil,
+		},
+		{
+			name: "BadInput",
+			arg: args{
+				iface: "fakeif0",
+				progMap: map[string]*list.List{
+					"fakeif0": setupBPFListsWithStopError("ratelimiting"),
+				},
+				bpfProgs: []string{"ratelimiting"},
+			},
+			want: errStopFailure,
+		},
+		{
+			name: "GoodInput",
+			arg: args{
+				iface: "fakeif0",
+				progMap: map[string]*list.List{
+					"fakeif0": list.New(),
+				},
+				bpfProgs: []string{"ratelimiting"},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &NFConfigs{
+				HostConfig: &config.Config{},
+			}
+			err := cfg.deleteProgramsByHook(tt.arg.iface, tt.arg.direction, tt.arg.progMap, tt.arg.bpfProgs)
+			if !errors.Is(err, tt.want) {
+				t.Errorf("deleteProgramsByHook failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeleteProgramsOnInterfaceHelper(t *testing.T) {
+	mockedList := setupBPFListsWithPutError("mocked")
+	mockedValidList := setupValidBPFList("mocked")
+	type fields struct {
+		ingressXDPBpfs map[string]*list.List
+		ingressTCBpfs  map[string]*list.List
+		egressTCBpfs   map[string]*list.List
+		hostConfig     *config.Config
+	}
+	type args struct {
+		e         *list.Element
+		iface     string
+		direction string
+		bpfList   *list.List
+	}
+	tests := []struct {
+		name  string
+		field fields
+		arg   args
+		want  error
+	}{
+		{
+			name: "NilProgram",
+			field: fields{
+				hostConfig: &config.Config{
+					BpfChainingEnabled: true,
+				},
+			},
+			arg: args{
+				e: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "StopError",
+			field: fields{
+				hostConfig: &config.Config{
+					BpfChainingEnabled: true,
+				},
+			},
+			arg: args{
+				e: &list.Element{
+					Value: &mocks.BPF{
+						MockName: func() string {
+							return "mocked"
+						},
+						MockStop: func(ifaceName, direction string, chain bool) error {
+							return errStopFailure
+						},
+						MockUpdateAdminStatus: func(value string) {
+							// do nothing
+						},
+					},
+				},
+			},
+			want: errStopFailure,
+		},
+		{
+			name: "BpfChainingDisabled",
+			field: fields{
+				hostConfig: &config.Config{
+					BpfChainingEnabled: false,
+				},
+			},
+			arg:  args{},
+			want: nil,
+		},
+		{
+			name: "NextNotNil",
+			field: fields{
+				hostConfig: &config.Config{
+					BpfChainingEnabled: true,
+				},
+			},
+			arg: args{
+				e:       mockedList.Front().Next(),
+				bpfList: mockedList,
+			},
+			want: errUpdateFdFailure,
+		},
+		{
+			name: "UnknownDirection",
+			field: fields{
+				hostConfig: &config.Config{
+					BpfChainingEnabled: true,
+				},
+			},
+			arg: args{
+				e:         mockedValidList.Back(),
+				bpfList:   mockedValidList,
+				direction: "random",
+			},
+			want: errUnknownDirection,
+		},
+		{
+			name: "GoodInput",
+			field: fields{
+				ingressXDPBpfs: map[string]*list.List{"fakeif0": nil},
+				ingressTCBpfs:  map[string]*list.List{"fakeif0": nil},
+				egressTCBpfs:   map[string]*list.List{"fakeif0": nil},
+				hostConfig: &config.Config{
+					BpfChainingEnabled: true,
+				},
+			},
+			arg: args{
+				e:         mockedValidList.Front(),
+				iface:     "fakeif0",
+				direction: models.XDPIngressType,
+				bpfList:   mockedValidList,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &NFConfigs{
+				IngressXDPBpfs: tt.field.ingressXDPBpfs,
+				IngressTCBpfs:  tt.field.ingressTCBpfs,
+				EgressTCBpfs:   tt.field.egressTCBpfs,
+				HostConfig:     tt.field.hostConfig,
+			}
+			err := cfg.deleteProgramsOnInterfaceHelper(tt.arg.e, tt.arg.iface, tt.arg.direction, tt.arg.bpfList)
+			if !errors.Is(err, tt.want) {
+				t.Errorf("deleteProgramsOnInterfaceHelper failed: %v", err)
+			}
+		})
+	}
+
 }
 
 func TestDeleteEbpfPrograms(t *testing.T) {

--- a/kf/processCheck.go
+++ b/kf/processCheck.go
@@ -5,9 +5,9 @@
 package kf
 
 import (
-	"container/list"
 	"time"
 
+	"github.com/l3af-project/l3afd/list"
 	"github.com/l3af-project/l3afd/models"
 	"github.com/l3af-project/l3afd/stats"
 

--- a/kf/processCheck_test.go
+++ b/kf/processCheck_test.go
@@ -4,10 +4,11 @@
 package kf
 
 import (
-	"container/list"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/l3af-project/l3afd/list"
 )
 
 func TestNewpCheck(t *testing.T) {

--- a/list/list.go
+++ b/list/list.go
@@ -1,0 +1,230 @@
+// Copyright Contributors to the L3AF Project.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package list implements container/list but for models.BPF
+package list
+
+import "github.com/l3af-project/l3afd/models"
+
+// Element is an element of a linked list.
+type Element struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev *Element
+
+	// The list to which this element belongs.
+	list *List
+
+	// The value stored with this element.
+	Value models.BPF
+}
+
+// Next returns the next list element or nil.
+func (e *Element) Next() *Element {
+	if p := e.next; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// Prev returns the previous list element or nil.
+func (e *Element) Prev() *Element {
+	if p := e.prev; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// List represents a doubly linked list.
+// The zero value for List is an empty list ready to use.
+type List struct {
+	root Element // sentinel list element, only &root, root.prev, and root.next are used
+	len  int     // current list length excluding (this) sentinel element
+}
+
+// Init initializes or clears list l.
+func (l *List) Init() *List {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	l.len = 0
+	return l
+}
+
+// New returns an initialized list.
+func New() *List { return new(List).Init() }
+
+// Len returns the number of elements of list l.
+// The complexity is O(1).
+func (l *List) Len() int { return l.len }
+
+// Front returns the first element of list l or nil if the list is empty.
+func (l *List) Front() *Element {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.next
+}
+
+// Back returns the last element of list l or nil if the list is empty.
+func (l *List) Back() *Element {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prev
+}
+
+// lazyInit lazily initializes a zero List value.
+func (l *List) lazyInit() {
+	if l.root.next == nil {
+		l.Init()
+	}
+}
+
+// insert inserts e after at, increments l.len, and returns e.
+func (l *List) insert(e, at *Element) *Element {
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+	e.list = l
+	l.len++
+	return e
+}
+
+// insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
+func (l *List) insertValue(v models.BPF, at *Element) *Element {
+	return l.insert(&Element{Value: v}, at)
+}
+
+// remove removes e from its list, decrements l.len
+func (l *List) remove(e *Element) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	e.list = nil
+	l.len--
+}
+
+// move moves e to next to at.
+func (l *List) move(e, at *Element) {
+	if e == at {
+		return
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+}
+
+// Remove removes e from l if e is an element of list l.
+// It returns the element value e.Value.
+// The element must not be nil.
+func (l *List) Remove(e *Element) any {
+	if e.list == l {
+		// if e.list == l, l must have been initialized when e was inserted
+		// in l or l == nil (e is a zero Element) and l.remove will crash
+		l.remove(e)
+	}
+	return e.Value
+}
+
+// PushFront inserts a new element e with value v at the front of list l and returns e.
+func (l *List) PushFront(v models.BPF) *Element {
+	l.lazyInit()
+	return l.insertValue(v, &l.root)
+}
+
+// PushBack inserts a new element e with value v at the back of list l and returns e.
+func (l *List) PushBack(v models.BPF) *Element {
+	l.lazyInit()
+	return l.insertValue(v, l.root.prev)
+}
+
+// InsertBefore inserts a new element e with value v immediately before mark and returns e.
+// If mark is not an element of l, the list is not modified.
+// The mark must not be nil.
+func (l *List) InsertBefore(v models.BPF, mark *Element) *Element {
+	if mark.list != l {
+		return nil
+	}
+	// see comment in List.Remove about initialization of l
+	return l.insertValue(v, mark.prev)
+}
+
+// InsertAfter inserts a new element e with value v immediately after mark and returns e.
+// If mark is not an element of l, the list is not modified.
+// The mark must not be nil.
+func (l *List) InsertAfter(v models.BPF, mark *Element) *Element {
+	if mark.list != l {
+		return nil
+	}
+	// see comment in List.Remove about initialization of l
+	return l.insertValue(v, mark)
+}
+
+// MoveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *List) MoveToFront(e *Element) {
+	if e.list != l || l.root.next == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, &l.root)
+}
+
+// MoveToBack moves element e to the back of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *List) MoveToBack(e *Element) {
+	if e.list != l || l.root.prev == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, l.root.prev)
+}
+
+// MoveBefore moves element e to its new position before mark.
+// If e or mark is not an element of l, or e == mark, the list is not modified.
+// The element and mark must not be nil.
+func (l *List) MoveBefore(e, mark *Element) {
+	if e.list != l || e == mark || mark.list != l {
+		return
+	}
+	l.move(e, mark.prev)
+}
+
+// MoveAfter moves element e to its new position after mark.
+// If e or mark is not an element of l, or e == mark, the list is not modified.
+// The element and mark must not be nil.
+func (l *List) MoveAfter(e, mark *Element) {
+	if e.list != l || e == mark || mark.list != l {
+		return
+	}
+	l.move(e, mark)
+}
+
+// PushBackList inserts a copy of another list at the back of list l.
+// The lists l and other may be the same. They must not be nil.
+func (l *List) PushBackList(other *List) {
+	l.lazyInit()
+	for i, e := other.Len(), other.Front(); i > 0; i, e = i-1, e.Next() {
+		l.insertValue(e.Value, l.root.prev)
+	}
+}
+
+// PushFrontList inserts a copy of another list at the front of list l.
+// The lists l and other may be the same. They must not be nil.
+func (l *List) PushFrontList(other *List) {
+	l.lazyInit()
+	for i, e := other.Len(), other.Back(); i > 0; i, e = i-1, e.Prev() {
+		l.insertValue(e.Value, &l.root)
+	}
+}

--- a/mocks/bpf.go
+++ b/mocks/bpf.go
@@ -1,0 +1,182 @@
+// Copyright Contributors to the L3AF Project.
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import (
+	"github.com/l3af-project/l3afd/config"
+	"github.com/l3af-project/l3afd/models"
+)
+
+// BPF is a mock models.BPF for testing
+type BPF struct {
+	MockName                    func() string
+	MockArtifact                func() string
+	MockMapName                 func() string
+	MockMapNamePth              func() string
+	MockPrevMapNamePth          func() string
+	MockProgId                  func() int
+	MockSeqId                   func() int
+	MockUpdatePrevMapNamePath   func(value string)
+	MockUpdateAdminStatus       func(value string)
+	MockStart                   func(ifaceName, direction string, chain bool) error
+	MockStop                    func(ifaceName, direction string, chain bool) error
+	MockUpdate                  func(ifaceName, direction string) error
+	MockVerifyAndGetArtifacts   func(conf *config.Config) error
+	MockGetArtifacts            func(conf *config.Config) error
+	MockAddBPFMap               func(mapName string) error
+	MockGetBPFMap               func(mapName string) (models.BPFMap, error)
+	MockAddMetricsBPFMap        func(mapName, aggregator string, key, samplesLength int) error
+	MockMonitorMaps             func(ifaceName string, intervals int) error
+	MockPutNextProgFDFromID     func(progsID int) error
+	MockGetProgID               func() (int, error)
+	MockRemoveNextProgFD        func() error
+	MockRemovePrevProgFD        func() error
+	MockVerifyPinnedMapExists   func(chain bool) error
+	MockVerifyPinnedMapVanish   func(chain bool) error
+	MockVerifyProcessObject     func() error
+	MockVerifyMetricsMapsVanish func() error
+}
+
+var _ models.BPF = &BPF{}
+
+// Name implements models.BPF.Name
+func (b *BPF) Name() string {
+	return b.MockName()
+}
+
+// Artifact implements models.BPF.Artifact
+func (b *BPF) Artifact() string {
+	return b.MockArtifact()
+}
+
+// MapName implements model.BPF.MapName
+func (b *BPF) MapName() string {
+	return b.MockMapName()
+}
+
+// MapNamePth implements model.BPF.MapNamePth
+func (b *BPF) MapNamePth() string {
+	return b.MockMapNamePth()
+}
+
+// PrevMapNamePth implements model.BPF.PrevMapNamePth
+func (b *BPF) PrevMapNamePth() string {
+	return b.MockPrevMapNamePth()
+}
+
+// ProgId implements models.BPF.ProgId
+func (b *BPF) ProgId() int {
+	return b.MockProgId()
+}
+
+// SeqId implements models.BPF.SeqId
+func (b *BPF) SeqId() int {
+	return b.MockSeqId()
+}
+
+// UpdatePrevMapNamePath implements models.BPF.UpdatePrevMapNamePath
+func (b *BPF) UpdatePrevMapNamePath(value string) {
+	b.MockUpdatePrevMapNamePath(value)
+}
+
+// UpdateAdminStatus implements models.BPF.ChangeAdminStatus
+func (b *BPF) UpdateAdminStatus(value string) {
+	b.MockUpdateAdminStatus(value)
+}
+
+// Start implements models.BPF.Start
+func (b *BPF) Start(ifaceName, direction string, chain bool) error {
+	return b.MockStart(ifaceName, direction, chain)
+}
+
+// Stop implements models.BPF.Stop
+func (b *BPF) Stop(ifaceName, direction string, chain bool) error {
+	return b.MockStop(ifaceName, direction, chain)
+}
+
+// Update implements models.BPF.Stop
+func (b *BPF) Update(ifaceName, direction string) error {
+	return b.MockUpdate(ifaceName, direction)
+}
+
+// VerifyAndGetArtifacts implements models.BPF.VerifyAndGetArtifact
+func (b *BPF) VerifyAndGetArtifacts(conf *config.Config) error {
+	return b.MockVerifyAndGetArtifacts(conf)
+}
+
+// GetArtifacts implements models.BPF.GetArtifacts
+func (b *BPF) GetArtifacts(conf *config.Config) error {
+	return b.MockGetArtifacts(conf)
+}
+
+// AddBPFMap implements models.BPF.AddBPFMap
+func (b *BPF) AddBPFMap(mapName string) error {
+	return b.MockAddBPFMap(mapName)
+}
+
+// GetBPFMap implements models.BPF.GetBPFMap
+func (b *BPF) GetBPFMap(mapName string) (models.BPFMap, error) {
+	return b.MockGetBPFMap(mapName)
+}
+
+// AddMetricsBPFMap implements models.BPF.AddMetricsBPFMap
+func (b *BPF) AddMetricsBPFMap(mapName, aggregator string, key, samplesLength int) error {
+	return b.MockAddMetricsBPFMap(mapName, aggregator, key, samplesLength)
+}
+
+// MontitorMaps implements models.BPF.MonitorMaps
+func (b *BPF) MonitorMaps(ifaceName string, intervals int) error {
+	return b.MockMonitorMaps(ifaceName, intervals)
+}
+
+// PutNextProgFDFromID implements models.BPF.PutNextProgFDFromID
+func (b *BPF) PutNextProgFDFromID(progsID int) error {
+	return b.MockPutNextProgFDFromID(progsID)
+}
+
+// GetProgID implements models.BPF.GetProgID
+func (b *BPF) GetProgID() (int, error) {
+	return b.MockGetProgID()
+}
+
+// RemoveNextProgFD implements models.BPF.RemoveNextProgFD
+func (b *BPF) RemoveNextProgFD() error {
+	return b.MockRemoveNextProgFD()
+}
+
+// RemovePrevProgID implements models.BPF.RemovePrevProgFD
+func (b *BPF) RemovePrevProgFD() error {
+	return b.MockRemovePrevProgFD()
+}
+
+// VerifyPinnedMapExists implements models.BPF.VerifyPinnedMapExists
+func (b *BPF) VerifyPinnedMapExists(chain bool) error {
+	return b.MockVerifyPinnedMapExists(chain)
+}
+
+// VerifyPinnedMapVanish implements models.BPF.VerifyPinnedMapVanish
+func (b *BPF) VerifyPinnedMapVanish(chain bool) error {
+	return b.MockVerifyPinnedMapVanish(chain)
+}
+
+// VerifyProcessObject implements models.BPF.VerifyProcessObject
+func (b *BPF) VerifyProcessObject() error {
+	return b.MockVerifyProcessObject()
+}
+
+// VerifyMetricsMapVanish implements models.BPF.VerifyMetricsMapVanish
+func (b *BPF) VerifyMetricsMapsVanish() error {
+	return b.MockVerifyMetricsMapsVanish()
+}
+
+type BPFMap struct {
+	MockUpdate func(value string) error
+}
+
+var _ models.BPFMap = &BPFMap{}
+
+// Update implements models.BPFMap.Update
+func (b *BPFMap) Update(value string) error {
+	return b.MockUpdate(value)
+}

--- a/models/bpf.go
+++ b/models/bpf.go
@@ -1,0 +1,93 @@
+// Copyright Contributors to the L3AF Project.
+// SPDX-License-Identifier: Apache-2.0
+
+package models
+
+import "github.com/l3af-project/l3afd/config"
+
+// BPF
+type BPF interface {
+	//
+	Name() string
+
+	//
+	Artifact() string
+
+	//
+	MapName() string
+
+	//
+	MapNamePth() string
+
+	//
+	PrevMapNamePth() string
+
+	//
+	ProgId() int
+
+	//
+	SeqId() int
+
+	//
+	UpdateAdminStatus(value string)
+
+	//
+	UpdatePrevMapNamePath(value string)
+
+	//
+	Start(ifaceName, direction string, chain bool) error
+
+	//
+	Stop(ifaceName, direction string, chain bool) error
+
+	//
+	Update(ifaceName, direction string) error
+
+	//
+	VerifyAndGetArtifacts(conf *config.Config) error
+
+	//
+	GetArtifacts(conf *config.Config) error
+
+	//
+	AddBPFMap(mapName string) error
+
+	//
+	GetBPFMap(mapName string) (BPFMap, error)
+
+	//
+	AddMetricsBPFMap(mapName, aggregator string, key, samplesLength int) error
+
+	//
+	MonitorMaps(ifaceName string, intervals int) error
+
+	//
+	PutNextProgFDFromID(progsID int) error
+
+	//
+	GetProgID() (int, error)
+
+	//
+	RemoveNextProgFD() error
+
+	//
+	RemovePrevProgFD() error
+
+	//
+	VerifyPinnedMapExists(chain bool) error
+
+	//
+	VerifyPinnedMapVanish(chain bool) error
+
+	//
+	VerifyProcessObject() error
+
+	//
+	VerifyMetricsMapsVanish() error
+}
+
+// BPFMap
+type BPFMap interface {
+	//
+	Update(value string) error
+}


### PR DESCRIPTION
This diff introduces a new mechanism for improving unit tests for the existing code. The main features of this PoC are:
- Introduce a parent interface to allow mocking concrete types
- Introduce `test$Func` fields in concrete types to mock functions
- Allow better error handling by defining the errors we expect. Further, also check the type of error we get (using `errors.Is`) while writing tests. 

This is part of https://github.com/l3af-project/l3afd/issues/223