### PR TITLE
Enabled opentelemetry support for metric export

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/spec v0.20.8 // indirect
@@ -31,10 +33,16 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
+	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a // indirect
+	go.opentelemetry.io/otel v1.16.0 // indirect
+	go.opentelemetry.io/otel/exporters/prometheus v0.39.0 // indirect
+	go.opentelemetry.io/otel/metric v1.16.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.16.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.39.0 // indirect
+	go.opentelemetry.io/otel/trace v1.16.0 // indirect
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/tools v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -14,6 +16,12 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
 github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
@@ -39,6 +47,9 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -59,6 +70,9 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -67,6 +81,8 @@ github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626
 github.com/prometheus/client_golang v1.16.0/go.mod h1:Zsulrv/L9oM40tJ7T815tM89lFEugiJ9HzIqaAx4LKc=
 github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
 github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
+github.com/prometheus/client_model v0.4.0 h1:5lQXD3cAg1OXBf4Wq03gTrXHeaV0TQvGfUooCfx1yqY=
+github.com/prometheus/client_model v0.4.0/go.mod h1:oMQmHW1/JoDwqLtg57MGgP/Fb1CJEYF2imWWhWtMkYU=
 github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI1YM=
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
@@ -74,6 +90,7 @@ github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPH
 github.com/robfig/config v0.0.0-20141207224736-0f78529c8c7e h1:3/9k/etUfgykjM3Rx8X0echJzo7gNNeND/ubPkqYw1k=
 github.com/robfig/config v0.0.0-20141207224736-0f78529c8c7e/go.mod h1:Zerq1qYbCKtIIU9QgPydffGlpYfZ8KI/si49wuTLY/Q=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.30.0 h1:SymVODrcRsaRaSInD9yQtKbtWqwsfoPcRff/oRXLj4c=
 github.com/rs/zerolog v1.30.0/go.mod h1:/tk+P47gFdPXq4QYjvCmT5/Gsug2nagsFWBWhAiSi1w=
@@ -88,6 +105,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a h1:kAe4YSu0O0UFn1DowNo2MY5p6xzqtJ/wQ7LZynSvGaY=
 github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a/go.mod h1:lKJPbtWzJ9JhsTN1k1gZgleJWY/cqq0psdoMmaThG3w=
 github.com/swaggo/http-swagger v1.3.4 h1:q7t/XLx0n15H1Q9/tk3Y9L4n210XzJF5WtnDX64a5ww=
@@ -95,6 +113,18 @@ github.com/swaggo/http-swagger v1.3.4/go.mod h1:9dAh0unqMBAlbp1uE2Uc2mQTxNMU/ha4
 github.com/swaggo/swag v1.16.1 h1:fTNRhKstPKxcnoKsytm4sahr8FaYzUcT7i1/3nd/fBg=
 github.com/swaggo/swag v1.16.1/go.mod h1:9/LMvHycG3NFHfR6LwvikHv5iFvmPADQ359cKikGxto=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.opentelemetry.io/otel v1.16.0 h1:Z7GVAX/UkAXPKsy94IU+i6thsQS4nb7LviLpnaNeW8s=
+go.opentelemetry.io/otel v1.16.0/go.mod h1:vl0h9NUa1D5s1nv3A5vZOYWn8av4K8Ml6JDeHrT/bx4=
+go.opentelemetry.io/otel/exporters/prometheus v0.39.0 h1:whAaiHxOatgtKd+w0dOi//1KUxj3KoPINZdtDaDj3IA=
+go.opentelemetry.io/otel/exporters/prometheus v0.39.0/go.mod h1:4jo5Q4CROlCpSPsXLhymi+LYrDXd2ObU5wbKayfZs7Y=
+go.opentelemetry.io/otel/metric v1.16.0 h1:RbrpwVG1Hfv85LgnZ7+txXioPDoh6EdbZHo26Q3hqOo=
+go.opentelemetry.io/otel/metric v1.16.0/go.mod h1:QE47cpOmkwipPiefDwo2wDzwJrlfxxNYodqc4xnGCo4=
+go.opentelemetry.io/otel/sdk v1.16.0 h1:Z1Ok1YsijYL0CSJpHt4cS3wDDh7p572grzNrBMiMWgE=
+go.opentelemetry.io/otel/sdk v1.16.0/go.mod h1:tMsIuKXuuIWPBAOrH+eHtvhTL+SntFtXF9QD68aP6p4=
+go.opentelemetry.io/otel/sdk/metric v0.39.0 h1:Kun8i1eYf48kHH83RucG93ffz0zGV1sh46FAScOTuDI=
+go.opentelemetry.io/otel/sdk/metric v0.39.0/go.mod h1:piDIRgjcK7u0HCL5pCA4e74qpK/jk3NiUoAHATVAmiI=
+go.opentelemetry.io/otel/trace v1.16.0 h1:8JRpaObFoW0pxuVPapkgH8UhHQj+bJW8jJsCZEu5MQs=
+go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLkqr2QVwea0ef0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=

--- a/stats/metric_values.go
+++ b/stats/metric_values.go
@@ -9,9 +9,9 @@ import (
 )
 
 type metricAttributes struct {
-	baseAttributeCount	int
-	MetricName			string
-	Attributes			[]attribute.KeyValue
+	baseAttributeCount  int
+	MetricName          string
+	Attributes          []attribute.KeyValue
 }
 
 func newMetricAttributes(metricName string, baseAttributes []attribute.KeyValue) *metricAttributes {

--- a/stats/metric_values.go
+++ b/stats/metric_values.go
@@ -1,0 +1,94 @@
+package stats
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	api "go.opentelemetry.io/otel/metric"
+)
+
+type MetricAttributes struct {
+	baseAttribCount		int
+	mutex				sync.RWMutex
+	MetricName			string
+	Attribs 			[]attribute.KeyValue
+}
+
+func NewMetricAttribs(metricName string, baseAttribs []attribute.KeyValue) *MetricAttributes {
+	retval := MetricAttributes {
+		MetricName: metricName,
+		Attribs: make([]attribute.KeyValue, len(baseAttribs) + 5),
+	}
+
+	copy(retval.Attribs, baseAttribs)
+	return &retval
+}
+
+func (metricAttribs *MetricAttributes) GetMeasurementOptions() api.MeasurementOption {
+	metricAttribs.mutex.Lock()
+	defer metricAttribs.mutex.Unlock()
+	
+	return api.WithAttributes(metricAttribs.Attribs...)
+}
+
+func (metricAttribs *MetricAttributes) SetAttributes(attribValuesToUpdate map[string]string) {
+	metricAttribs.mutex.Lock()
+	defer metricAttribs.mutex.Unlock()
+	
+	metricAttribs.Attribs = metricAttribs.Attribs[:metricAttribs.baseAttribCount]
+	for name, value := range attribValuesToUpdate {
+		metricAttribs.Attribs = append(metricAttribs.Attribs, attribute.Key(name).String(value))
+	}
+}
+
+// =====================================================
+type GaugeValue struct {
+	Gauge				*api.Float64ObservableGauge
+	Value				float64
+	*MetricAttributes
+}
+
+func NewGaugeValue(gauge *api.Float64ObservableGauge, metricName string, attribs []attribute.KeyValue) *GaugeValue {
+	return &GaugeValue {
+		Gauge: gauge,
+		Value: 0,
+		MetricAttributes: NewMetricAttribs(metricName, attribs),
+	}
+}
+
+func (gaugeValue *GaugeValue) GetValue() float64 {
+	gaugeValue.mutex.Lock()
+	defer gaugeValue.mutex.Unlock()
+
+	return gaugeValue.Value
+}
+
+func (gaugeValue *GaugeValue) SetValue(val float64) {
+	gaugeValue.mutex.Lock()
+	defer gaugeValue.mutex.Unlock()
+	
+	gaugeValue.Value = val
+}
+
+// =====================================================
+type CounterValue struct {
+	Ctx 				context.Context
+	Counter 			*api.Int64Counter
+	Value 				int64
+	*MetricAttributes
+
+}
+
+func NewCounterValue(ctx context.Context, counter *api.Int64Counter, metricName string, attribs []attribute.KeyValue) *CounterValue {
+	return &CounterValue{
+		Ctx: ctx,
+		Counter: counter,
+		Value: 0,
+		MetricAttributes: NewMetricAttribs(metricName, attribs),
+	}
+}
+
+func (counterValue *CounterValue) Increment() {
+	(*(counterValue.Counter)).Add(counterValue.Ctx, 1, counterValue.GetMeasurementOptions())
+}

--- a/stats/metric_values.go
+++ b/stats/metric_values.go
@@ -9,33 +9,33 @@ import (
 )
 
 type metricAttributes struct {
-	baseAttribCount		int
+	baseAttributeCount	int
 	MetricName			string
-	Attribs 			[]attribute.KeyValue
+	Attributes			[]attribute.KeyValue
 }
 
-func newMetricAttribs(metricName string, baseAttribs []attribute.KeyValue) *metricAttributes {
+func newMetricAttributes(metricName string, baseAttributes []attribute.KeyValue) *metricAttributes {
 	retval := metricAttributes {
 		MetricName: metricName,
-		Attribs: make([]attribute.KeyValue, len(baseAttribs)),
+		Attributes: make([]attribute.KeyValue, len(baseAttributes)),
 	}
 
-	copy(retval.Attribs, baseAttribs)
+	copy(retval.Attributes, baseAttributes)
 	return &retval
 }
 
-func (metricAttribs *metricAttributes) getMeasurementOptions(attribsToInclude []attribute.KeyValue) api.MeasurementOption {
-	if attribsToInclude != nil {
-		updatedAttribs := append(metricAttribs.Attribs, attribsToInclude...)
-		return api.WithAttributes(updatedAttribs...)
+func (metricAttributes *metricAttributes) getMeasurementOptions(attributesToInclude []attribute.KeyValue) api.MeasurementOption {
+	if attributesToInclude != nil {
+		updatedAttributes := append(metricAttributes.Attributes, attributesToInclude...)
+		return api.WithAttributes(updatedAttributes...)
 	}
 
-	return api.WithAttributes(metricAttribs.Attribs...)
+	return api.WithAttributes(metricAttributes.Attributes...)
 }
 
-func (metricAttribs *metricAttributes) setAttributes(newAttribValues []attribute.KeyValue) {
-	metricAttribs.Attribs = metricAttribs.Attribs[:metricAttribs.baseAttribCount]
-	metricAttribs.Attribs = append(metricAttribs.Attribs, newAttribValues...)
+func (metricAttributes *metricAttributes) setAttributes(newAttribValues []attribute.KeyValue) {
+	metricAttributes.Attributes = metricAttributes.Attributes[:metricAttributes.baseAttributeCount]
+	metricAttributes.Attributes = append(metricAttributes.Attributes, newAttribValues...)
 }
 
 // =====================================================
@@ -46,11 +46,11 @@ type GaugeValue struct {
 	*metricAttributes
 }
 
-func NewGaugeValue(gauge *api.Float64ObservableGauge, metricName string, attribs []attribute.KeyValue) *GaugeValue {
+func NewGaugeValue(gauge *api.Float64ObservableGauge, metricName string, attributes []attribute.KeyValue) *GaugeValue {
 	return &GaugeValue {
 		Gauge: gauge,
 		Value: 0,
-		metricAttributes: newMetricAttribs(metricName, attribs),
+		metricAttributes: newMetricAttributes(metricName, attributes),
 	}
 }
 
@@ -61,11 +61,11 @@ func (gaugeValue *GaugeValue) GetMeasurementOptions() api.MeasurementOption {
 	return gaugeValue.getMeasurementOptions(nil)
 }
 
-func (gaugeValue *GaugeValue) SetValue(val float64, attribs []attribute.KeyValue) {
+func (gaugeValue *GaugeValue) SetValue(val float64, attributes []attribute.KeyValue) {
 	gaugeValue.mutex.Lock()
 	defer gaugeValue.mutex.Unlock()
 
-	gaugeValue.metricAttributes.setAttributes(attribs)
+	gaugeValue.metricAttributes.setAttributes(attributes)
 	gaugeValue.Value = val
 }
 
@@ -84,15 +84,15 @@ type CounterValue struct {
 	*metricAttributes
 }
 
-func NewCounterValue(ctx context.Context, counter *api.Int64Counter, metricName string, attribs []attribute.KeyValue) *CounterValue {
+func NewCounterValue(ctx context.Context, counter *api.Int64Counter, metricName string, attributes []attribute.KeyValue) *CounterValue {
 	return &CounterValue{
 		Ctx: ctx,
 		Counter: counter,
 		Value: 0,
-		metricAttributes: newMetricAttribs(metricName, attribs),
+		metricAttributes: newMetricAttributes(metricName, attributes),
 	}
 }
 
-func (counterValue *CounterValue) Increment(attribs []attribute.KeyValue) {
-	(*(counterValue.Counter)).Add(counterValue.Ctx, 1, counterValue.getMeasurementOptions(attribs))
+func (counterValue *CounterValue) Increment(attributes []attribute.KeyValue) {
+	(*(counterValue.Counter)).Add(counterValue.Ctx, 1, counterValue.getMeasurementOptions(attributes))
 }

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -3,198 +3,182 @@
 
 package stats
 
+/*
+	TODO:
+		- Remove dependent modules
+			"github.com/prometheus/client_golang/prometheus"
+			"github.com/prometheus/client_golang/prometheus/promauto"
+			"github.com/prometheus/client_golang/prometheus/promhttp"
+*/
 import (
+	"context"
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	api "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/metric"
+
 	"github.com/rs/zerolog/log"
 )
 
 var (
-	NFStartCount  *prometheus.CounterVec
-	NFStopCount   *prometheus.CounterVec
-	NFUpdateCount *prometheus.CounterVec
-	NFRunning     *prometheus.GaugeVec
-	NFStartTime   *prometheus.GaugeVec
-	NFMonitorMap  *prometheus.GaugeVec
+	NFStartCount  *CounterValue
+	NFStopCount   *CounterValue
+	NFUpdateCount *CounterValue
+	NFRunning     *GaugeValue
+	NFStartTime   *GaugeValue
+	NFMonitorMap  *GaugeValue
 )
 
 func SetupMetrics(hostname, daemonName, metricsAddr string) {
+	ctx := context.Background()
 
-	nfStartCountVec := promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: daemonName,
-			Name:      "NFStartCount",
-			Help:      "The count of network functions started",
-		},
-		[]string{"host", "ebpf_program", "direction", "interface_name"},
-	)
-
-	NFStartCount = nfStartCountVec.MustCurryWith(prometheus.Labels{"host": hostname})
-
-	nfStopCountVec := promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: daemonName,
-			Name:      "NFStopCount",
-			Help:      "The count of network functions stopped",
-		},
-		[]string{"host", "ebpf_program", "direction", "interface_name"},
-	)
-
-	NFStopCount = nfStopCountVec.MustCurryWith(prometheus.Labels{"host": hostname})
-
-	nfUpdateCountVec := promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: daemonName,
-			Name:      "NFUpdateCount",
-			Help:      "The count of network functions updated",
-		},
-		[]string{"host", "ebpf_program", "direction", "interface_name"},
-	)
-
-	NFUpdateCount = nfUpdateCountVec.MustCurryWith(prometheus.Labels{"host": hostname})
-
-	nfRunningVec := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: daemonName,
-			Name:      "NFRunning",
-			Help:      "This value indicates network functions is running or not",
-		},
-		[]string{"host", "ebpf_program", "version", "direction", "interface_name"},
-	)
-
-	if err := prometheus.Register(nfRunningVec); err != nil {
-		log.Warn().Err(err).Msg("Failed to register NFRunning metrics")
+	exporter, err := prometheus.New()
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Failed to create Prometheus exporter")
 	}
+	provider := metric.NewMeterProvider(metric.WithReader(exporter))
+	meter := provider.Meter("l3af-project/l3afd")
 
-	NFRunning = nfRunningVec.MustCurryWith(prometheus.Labels{"host": hostname})
+	baseAttribs := []attribute.KeyValue { attribute.Key("host").String(hostname) }
 
-	nfStartTimeVec := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: daemonName,
-			Name:      "NFStartTime",
-			Help:      "This value indicates start time of the network function since unix epoch in seconds",
-		},
-		[]string{"host", "ebpf_program", "direction", "interface_name"},
-	)
-
-	if err := prometheus.Register(nfStartTimeVec); err != nil {
-		log.Warn().Err(err).Msg("Failed to register NFStartTime metrics")
+	metricName := daemonName + "_NFStartCount"
+	startCount, err := meter.Int64Counter(metricName, api.WithDescription("The count of network functions started"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create NFStartCount")
 	}
+	NFStartCount = NewCounterValue(ctx, &startCount, metricName, baseAttribs)
 
-	NFStartTime = nfStartTimeVec.MustCurryWith(prometheus.Labels{"host": hostname})
-
-	nfMonitorMapVec := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: daemonName,
-			Name:      "NFMonitorMap",
-			Help:      "This value indicates network function monitor counters",
-		},
-		[]string{"host", "ebpf_program", "map_name", "interface_name"},
-	)
-
-	if err := prometheus.Register(nfMonitorMapVec); err != nil {
-		log.Warn().Err(err).Msg("Failed to register NFMonitorMap metrics")
+	metricName = daemonName + "_NFStopCount"
+	stopCount, err := meter.Int64Counter(metricName, api.WithDescription("The count of network functions stopped"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create NFStartCount")
 	}
+	NFStopCount = NewCounterValue(ctx, &stopCount, metricName, baseAttribs)
 
-	NFMonitorMap = nfMonitorMapVec.MustCurryWith(prometheus.Labels{"host": hostname})
+	metricName = daemonName + "_NFUpdateCount"
+	updateCount, err := meter.Int64Counter(metricName, api.WithDescription("The count of network functions updated"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create NFUpdateCount")
+	}
+	NFUpdateCount = NewCounterValue(ctx, &updateCount, metricName, baseAttribs)
 
-	// Prometheus handler
-	metricsHandler := promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{})
+	gaugeValues := []*GaugeValue{}
+
+	metricName = daemonName + "_NFRunning"
+	runningGugage, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates network functions is running or not"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create NFRunning")
+	}
+	NFRunning = NewGaugeValue(&runningGugage, metricName, baseAttribs)
+	gaugeValues = append(gaugeValues, NFRunning)
+
+	metricName = daemonName + "_NFStartTime"
+	startTimeGuage, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates start time of the network function since unix epoch in seconds"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create NFStartTime")
+	}
+	NFStartTime = NewGaugeValue(&startTimeGuage, metricName, baseAttribs)
+	gaugeValues = append(gaugeValues, NFStartTime)
+
+	metricName = daemonName + "_NFMonitorMap"
+	monitorMapGuage, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates network function monitor counters"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create NFMonitorMap")
+	}
+	NFMonitorMap = NewGaugeValue(&monitorMapGuage, metricName, baseAttribs)
+	gaugeValues = append(gaugeValues, NFMonitorMap)
+
+	// Gauge value update is done through callback
+	for _, gaugeVal := range gaugeValues {
+		gaugeCopy := gaugeVal.Gauge
+		_, err = meter.RegisterCallback(func(_ context.Context, o api.Observer) error {
+			o.ObserveFloat64(*gaugeCopy, gaugeVal.GetValue(), gaugeVal.GetMeasurementOptions())
+			return nil
+		}, *gaugeCopy)
+
+		if err != nil {
+			log.Warn().Err(err).Msgf("Failed to update metric value for %s", gaugeVal.MetricName)
+		}
+	}
 
 	// Adding web endpoint
 	go func() {
 		// Expose the registered metrics via HTTP.
-		http.Handle("/metrics", metricsHandler)
+		http.Handle("/metrics", promhttp.Handler())
 		if err := http.ListenAndServe(metricsAddr, nil); err != nil {
-			log.Fatal().Err(err).Msgf("Failed to launch prometheus metrics endpoint")
+			log.Fatal().Err(err).Msg("Failed to launch prometheus metrics endpoint")
 		}
 	}()
 }
 
-func Incr(counterVec *prometheus.CounterVec, ebpfProgram, direction, ifaceName string) {
+func Incr(counterVec *CounterValue, ebpfProgram, direction, ifaceName string) {
 
 	if counterVec == nil {
 		log.Warn().Msg("Metrics: counter vector is nil and needs to be initialized before Incr")
 		return
 	}
-	nfCounter, err := counterVec.GetMetricWith(
-		prometheus.Labels(map[string]string{
-			"ebpf_program":   ebpfProgram,
-			"direction":      direction,
-			"interface_name": ifaceName,
-		}),
-	)
-	if err != nil {
-		log.Warn().Msgf("Metrics: unable to fetch counter with fields: ebpf_program: %s, direction: %s, interface_name: %s",
-			ebpfProgram, direction, ifaceName)
-		return
+
+	updatedAttributes := map[string]string {
+		"ebpf_program": ebpfProgram,
+		"direction": direction,
+		"ifaceName": ifaceName,
 	}
-	nfCounter.Inc()
+
+	counterVec.SetAttributes(updatedAttributes)
+	counterVec.Increment()
 }
 
-func Set(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, direction, ifaceName string) {
+func Set(value float64, gaugeVec *GaugeValue, ebpfProgram, direction, ifaceName string) {
 
 	if gaugeVec == nil {
 		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before Set")
 		return
 	}
-	nfGauge, err := gaugeVec.GetMetricWith(
-		prometheus.Labels(map[string]string{
-			"ebpf_program":   ebpfProgram,
-			"direction":      direction,
-			"interface_name": ifaceName,
-		}),
-	)
-	if err != nil {
-		log.Warn().Msgf("Metrics: unable to fetch gauge with fields: ebpf_program: %s, direction: %s, interface_name: %s",
-			ebpfProgram, direction, ifaceName)
-		return
+
+	updatedAttributes := map[string]string {
+		"ebpf_program":   ebpfProgram,
+		"direction":      direction,
+		"interface_name": ifaceName,
 	}
-	nfGauge.Set(value)
+
+	gaugeVec.SetAttributes(updatedAttributes)
+	gaugeVec.SetValue(value)
 }
 
-func SetValue(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, mapName, ifaceName string) {
+func SetValue(value float64, gaugeVec *GaugeValue, ebpfProgram, mapName, ifaceName string) {
 
 	if gaugeVec == nil {
 		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before SetValue")
 		return
 	}
-	nfGauge, err := gaugeVec.GetMetricWith(
-		prometheus.Labels(map[string]string{
-			"ebpf_program":   ebpfProgram,
-			"map_name":       mapName,
-			"interface_name": ifaceName,
-		}),
-	)
-	if err != nil {
-		log.Warn().Msgf("Metrics: unable to fetch gauge with fields: ebpf_program: %s, map_name: %s, interface_name: %s",
-			ebpfProgram, mapName, ifaceName)
-		return
+
+	updatedAttributes := map[string]string {
+		"ebpf_program":   ebpfProgram,
+		"map_name":       mapName,
+		"interface_name": ifaceName,
 	}
-	nfGauge.Set(value)
+
+	gaugeVec.SetAttributes(updatedAttributes)
+	gaugeVec.SetValue(value)
 }
 
-func SetWithVersion(value float64, gaugeVec *prometheus.GaugeVec, ebpfProgram, version, direction, ifaceName string) {
+func SetWithVersion(value float64, gaugeVec *GaugeValue, ebpfProgram, version, direction, ifaceName string) {
 
 	if gaugeVec == nil {
 		log.Warn().Msg("Metrics: gauge vector is nil and needs to be initialized before Set")
 		return
 	}
-	nfGauge, err := gaugeVec.GetMetricWith(
-		prometheus.Labels(map[string]string{
-			"ebpf_program":   ebpfProgram,
-			"version":        version,
-			"direction":      direction,
-			"interface_name": ifaceName,
-		}),
-	)
-	if err != nil {
-		log.Warn().Msgf("Metrics: unable to fetch gauge with fields: ebpf_program: %s, version: %s, direction: %s, interface_name: %s",
-			ebpfProgram, version, direction, ifaceName)
-		return
+
+	updatedAttributes := map[string]string {
+		"ebpf_program":   ebpfProgram,
+		"version":        version,
+		"direction":      direction,
+		"interface_name": ifaceName,
 	}
-	nfGauge.Set(value)
+
+	gaugeVec.SetAttributes(updatedAttributes)
+	gaugeVec.SetValue(value)
 }

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -3,13 +3,6 @@
 
 package stats
 
-/*
-	TODO:
-		- Remove dependent modules
-			"github.com/prometheus/client_golang/prometheus"
-			"github.com/prometheus/client_golang/prometheus/promauto"
-			"github.com/prometheus/client_golang/prometheus/promhttp"
-*/
 import (
 	"context"
 	"net/http"

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -93,11 +93,11 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 
 	// Gauge value update is done through callback
 	for _, gaugeVal := range gaugeValues {
-		gaugeCopy := gaugeVal.Gauge
+		gauge := gaugeVal.Gauge
 		_, err = meter.RegisterCallback(func(_ context.Context, o api.Observer) error {
-			o.ObserveFloat64(*gaugeCopy, gaugeVal.GetValue(), gaugeVal.GetMeasurementOptions())
+			o.ObserveFloat64(*gauge, gaugeVal.GetValue(), gaugeVal.GetMeasurementOptions())
 			return nil
-		}, *gaugeCopy)
+		}, *gauge)
 
 		if err != nil {
 			log.Warn().Err(err).Msgf("Failed to update metric value for %s", gaugeVal.MetricName)
@@ -121,14 +121,13 @@ func Incr(counterVec *CounterValue, ebpfProgram, direction, ifaceName string) {
 		return
 	}
 
-	updatedAttributes := map[string]string {
-		"ebpf_program": ebpfProgram,
-		"direction": direction,
-		"ifaceName": ifaceName,
+	updatedAttributes := []attribute.KeyValue {
+		attribute.String("ebpf_program", ebpfProgram),
+		attribute.String("direction", direction),
+		attribute.String("ifaceName", ifaceName),
 	}
 
-	counterVec.SetAttributes(updatedAttributes)
-	counterVec.Increment()
+	counterVec.Increment(updatedAttributes)
 }
 
 func Set(value float64, gaugeVec *GaugeValue, ebpfProgram, direction, ifaceName string) {
@@ -138,14 +137,13 @@ func Set(value float64, gaugeVec *GaugeValue, ebpfProgram, direction, ifaceName 
 		return
 	}
 
-	updatedAttributes := map[string]string {
-		"ebpf_program":   ebpfProgram,
-		"direction":      direction,
-		"interface_name": ifaceName,
+	updatedAttributes := []attribute.KeyValue {
+		attribute.String("ebpf_program", ebpfProgram),
+		attribute.String("direction", direction),
+		attribute.String("ifaceName", ifaceName),
 	}
 
-	gaugeVec.SetAttributes(updatedAttributes)
-	gaugeVec.SetValue(value)
+	gaugeVec.SetValue(value, updatedAttributes)
 }
 
 func SetValue(value float64, gaugeVec *GaugeValue, ebpfProgram, mapName, ifaceName string) {
@@ -155,14 +153,13 @@ func SetValue(value float64, gaugeVec *GaugeValue, ebpfProgram, mapName, ifaceNa
 		return
 	}
 
-	updatedAttributes := map[string]string {
-		"ebpf_program":   ebpfProgram,
-		"map_name":       mapName,
-		"interface_name": ifaceName,
+	updatedAttributes := []attribute.KeyValue {
+		attribute.String("ebpf_program", ebpfProgram),
+		attribute.String("map_name", mapName),
+		attribute.String("interface_name", ifaceName),
 	}
 
-	gaugeVec.SetAttributes(updatedAttributes)
-	gaugeVec.SetValue(value)
+	gaugeVec.SetValue(value, updatedAttributes)
 }
 
 func SetWithVersion(value float64, gaugeVec *GaugeValue, ebpfProgram, version, direction, ifaceName string) {
@@ -172,13 +169,12 @@ func SetWithVersion(value float64, gaugeVec *GaugeValue, ebpfProgram, version, d
 		return
 	}
 
-	updatedAttributes := map[string]string {
-		"ebpf_program":   ebpfProgram,
-		"version":        version,
-		"direction":      direction,
-		"interface_name": ifaceName,
+	updatedAttributes := []attribute.KeyValue {
+		attribute.String("ebpf_program", ebpfProgram),
+		attribute.String("version", version),
+		attribute.String("direction", direction),
+		attribute.String("interface_name", ifaceName),
 	}
 
-	gaugeVec.SetAttributes(updatedAttributes)
-	gaugeVec.SetValue(value)
+	gaugeVec.SetValue(value, updatedAttributes)
 }

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -35,53 +35,53 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 	provider := metric.NewMeterProvider(metric.WithReader(exporter))
 	meter := provider.Meter("l3af-project/l3afd")
 
-	baseAttribs := []attribute.KeyValue { attribute.Key("host").String(hostname) }
+	baseAttributes := []attribute.KeyValue { attribute.Key("host").String(hostname) }
 
 	metricName := daemonName + "_NFStartCount"
 	startCount, err := meter.Int64Counter(metricName, api.WithDescription("The count of network functions started"))
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create NFStartCount")
 	}
-	NFStartCount = NewCounterValue(ctx, &startCount, metricName, baseAttribs)
+	NFStartCount = NewCounterValue(ctx, &startCount, metricName, baseAttributes)
 
 	metricName = daemonName + "_NFStopCount"
 	stopCount, err := meter.Int64Counter(metricName, api.WithDescription("The count of network functions stopped"))
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create NFStartCount")
 	}
-	NFStopCount = NewCounterValue(ctx, &stopCount, metricName, baseAttribs)
+	NFStopCount = NewCounterValue(ctx, &stopCount, metricName, baseAttributes)
 
 	metricName = daemonName + "_NFUpdateCount"
 	updateCount, err := meter.Int64Counter(metricName, api.WithDescription("The count of network functions updated"))
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create NFUpdateCount")
 	}
-	NFUpdateCount = NewCounterValue(ctx, &updateCount, metricName, baseAttribs)
+	NFUpdateCount = NewCounterValue(ctx, &updateCount, metricName, baseAttributes)
 
 	gaugeValues := []*GaugeValue{}
 
 	metricName = daemonName + "_NFRunning"
-	runningGugage, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates network functions is running or not"))
+	runningGauge, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates network functions is running or not"))
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create NFRunning")
 	}
-	NFRunning = NewGaugeValue(&runningGugage, metricName, baseAttribs)
+	NFRunning = NewGaugeValue(&runningGauge, metricName, baseAttributes)
 	gaugeValues = append(gaugeValues, NFRunning)
 
 	metricName = daemonName + "_NFStartTime"
-	startTimeGuage, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates start time of the network function since unix epoch in seconds"))
+	startTimeGauge, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates start time of the network function since unix epoch in seconds"))
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create NFStartTime")
 	}
-	NFStartTime = NewGaugeValue(&startTimeGuage, metricName, baseAttribs)
+	NFStartTime = NewGaugeValue(&startTimeGauge, metricName, baseAttributes)
 	gaugeValues = append(gaugeValues, NFStartTime)
 
 	metricName = daemonName + "_NFMonitorMap"
-	monitorMapGuage, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates network function monitor counters"))
+	monitorMapGauge, err := meter.Float64ObservableGauge(metricName, api.WithDescription("This value indicates network function monitor counters"))
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create NFMonitorMap")
 	}
-	NFMonitorMap = NewGaugeValue(&monitorMapGuage, metricName, baseAttribs)
+	NFMonitorMap = NewGaugeValue(&monitorMapGauge, metricName, baseAttributes)
 	gaugeValues = append(gaugeValues, NFMonitorMap)
 
 	// Gauge value update is done through callback


### PR DESCRIPTION
1. Enabled opentelemetry support for metrics export.
2. All metrics exported are in Prometheus format so additional changes required in documentation, environment setup, etc.
3. Plan for next set of changes is to export all metrics to opentelemetry collector from which backend monitoring systems can scraping data.