### PR TITLE
L3AFD metric for ebpf program update command failure count

### DIFF
--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -517,11 +517,13 @@ func (b *BPF) UpdateArgs(ifaceName, direction string) error {
 	log.Info().Msgf("BPF Program update command : %s %v", cmd, args)
 	UpdateCmd := execCommand(cmd, args...)
 	if err := UpdateCmd.Start(); err != nil {
+		stats.Incr(stats.NFUpdateFailedCount, b.Program.Name, direction, ifaceName)
 		log.Info().Err(err).Msgf("user mode BPF program failed - %s", b.Program.Name)
 		return fmt.Errorf("failed to start : %s %v", cmd, args)
 	}
 
 	if err := UpdateCmd.Wait(); err != nil {
+		stats.Incr(stats.NFUpdateFailedCount, b.Program.Name, direction, ifaceName)
 		return fmt.Errorf("cmd wait at starting of bpf program returned with error %v", err)
 	}
 

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -13,12 +13,13 @@ import (
 )
 
 var (
-	NFStartCount  *prometheus.CounterVec
-	NFStopCount   *prometheus.CounterVec
-	NFUpdateCount *prometheus.CounterVec
-	NFRunning     *prometheus.GaugeVec
-	NFStartTime   *prometheus.GaugeVec
-	NFMonitorMap  *prometheus.GaugeVec
+	NFStartCount        *prometheus.CounterVec
+	NFStopCount         *prometheus.CounterVec
+	NFUpdateCount       *prometheus.CounterVec
+	NFUpdateFailedCount *prometheus.CounterVec
+	NFRunning           *prometheus.GaugeVec
+	NFStartTime         *prometheus.GaugeVec
+	NFMonitorMap        *prometheus.GaugeVec
 )
 
 func SetupMetrics(hostname, daemonName, metricsAddr string) {
@@ -55,6 +56,17 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 	)
 
 	NFUpdateCount = nfUpdateCountVec.MustCurryWith(prometheus.Labels{"host": hostname})
+
+	nfUpdateFailedCountVec := promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: daemonName,
+			Name:      "NFUpdateFailedCount",
+			Help:      "The count of Failed network functions updates",
+		},
+		[]string{"host", "ebpf_program", "direction", "interface_name"},
+	)
+
+	NFUpdateFailedCount = nfUpdateFailedCountVec.MustCurryWith(prometheus.Labels{"host": hostname})
 
 	nfRunningVec := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -61,9 +61,9 @@ func SetupMetrics(hostname, daemonName, metricsAddr string) {
 		prometheus.CounterOpts{
 			Namespace: daemonName,
 			Name:      "NFUpdateFailedCount",
-			Help:      "The count of Failed network functions updates",
+			Help:      "The count of Failed eBPF programs updates",
 		},
-		[]string{"host", "ebpf_program", "direction", "interface_name"},
+		[]string{"host", "bpf_program", "direction", "interface_name"},
 	)
 
 	NFUpdateFailedCount = nfUpdateFailedCountVec.MustCurryWith(prometheus.Labels{"host": hostname})


### PR DESCRIPTION
A new metric is added to track Update failures of eBPF Function. This PR fixes the issue reported in [#282](https://github.com/l3af-project/l3afd/issues/282)