### PR TITLE
added the case where ProgId can'nt be updated

### DIFF
--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1337,6 +1337,9 @@ func (b *BPF) InitialiseMetricMaps() error {
 // IsLoaded - Method verifies whether bpf program is loaded or not
 // Here it checks whether prog ID is valid and active
 func (b *BPF) IsLoaded() bool {
+	if b.ProgID == 0 {
+		return true
+	}
 	ebpfProg, err := ebpf.NewProgramFromID(b.ProgID)
 	if err != nil && errors.Is(err, os.ErrNotExist) {
 		log.Debug().Msgf("IsLoaded - %s is not loaded or invalid program id %d", b.Program.Name, uint32(b.ProgID))


### PR DESCRIPTION
Basically when we are loading from only user program (UserProgramDaemon is true)  then we can'nt fetch ProgID . so when 
**IsRunning** function calls the **IsLoaded** it we will fail. In this PR I am fixing that issue.