### PR TITLE
fix the map files removal issue

### DIFF
--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1100,9 +1100,9 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 	for k, v := range b.ProgMapCollection.Maps {
 		var mapFilename string
 		if b.Program.ProgType == models.TCType {
-			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, models.TCMapPinPath, ifaceName, k)
+			mapFilename, _ = ValidatePath(b.hostConfig.BpfMapDefaultPath, models.TCMapPinPath, ifaceName, k)
 		} else {
-			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
+			mapFilename, _ = ValidatePath(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
 		}
 		if err := v.Unpin(); err != nil {
 			return fmt.Errorf("bpf program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",
@@ -1163,13 +1163,13 @@ func (b *BPF) VerifyCleanupMaps(chain bool) error {
 	return nil
 }
 
-func ValidatePath(filePath string, destination string) (string, error) {
-	destpath := filepath.Join(destination, filePath)
-	if strings.Contains(filePath, "..") {
-		return "", fmt.Errorf(" file contains filepath (%s) that includes (..)", filePath)
+func ValidatePath(filePath ...string) (string, error) {
+	destpath := ""
+	for _, x := range filePath {
+		destpath = filepath.Join(destpath, x)
 	}
-	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
-		return "", fmt.Errorf("%s: illegal file path", filePath)
+	if strings.Contains(destpath, "..") {
+		return "", fmt.Errorf(" file contains filepath (%s) that includes (..)", filePath)
 	}
 	return destpath, nil
 }

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1101,14 +1101,11 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 		var mapFilename string
 		if b.Program.ProgType == models.TCType {
 			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, models.TCMapPinPath, ifaceName, k)
-			if !strings.HasPrefix(mapFilename, b.hostConfig.BpfMapDefaultPath) {
-				return fmt.Errorf("malicious mapFilename path")
-			}
 		} else {
 			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
-			if !strings.HasPrefix(mapFilename, b.hostConfig.BpfMapDefaultPath) {
-				return fmt.Errorf("malicious mapFilename path")
-			}
+		}
+		if !strings.HasPrefix(mapFilename, b.hostConfig.BpfMapDefaultPath) {
+			return fmt.Errorf("malicious mapFilename path")
 		}
 		if err := v.Unpin(); err != nil {
 			return fmt.Errorf("bpf program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1105,13 +1105,13 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
 		}
 		if err := v.Unpin(); err != nil {
-			return fmt.Errorf("BPF program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",
+			return fmt.Errorf("bpf program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",
 				b.Program.Name, b.Program.ProgType, ifaceName, mapFilename, err)
 		}
 		if fileExists(filepath.Clean(mapFilename)) {
-			log.Warn().Msgf("Unpinning not able to remove map file : %v", mapFilename)
-			if err := os.RemoveAll(mapFilename); err != nil {
-				return fmt.Errorf("Removal of %v failed", mapFilename)
+			log.Warn().Msgf("unpinning not able to remove map file : %v", mapFilename)
+			if err := os.RemoveAll(filepath.Clean(mapFilename)); err != nil {
+				return fmt.Errorf("removal of %v failed", mapFilename)
 			}
 		}
 	}

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1108,9 +1108,9 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 			return fmt.Errorf("bpf program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",
 				b.Program.Name, b.Program.ProgType, ifaceName, mapFilename, err)
 		}
-		if fileExists(filepath.Clean(mapFilename)) {
+		if fileExists(mapFilename) {
 			log.Warn().Msgf("unpinning not able to remove map file : %v", mapFilename)
-			if err := os.RemoveAll(filepath.Clean(mapFilename)); err != nil {
+			if err := os.RemoveAll(mapFilename); err != nil {
 				return fmt.Errorf("removal of %v failed", mapFilename)
 			}
 		}

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1108,7 +1108,7 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 			return fmt.Errorf("BPF program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",
 				b.Program.Name, b.Program.ProgType, ifaceName, mapFilename, err)
 		}
-		if fileExists(mapFilename) {
+		if fileExists(filepath.Clean(mapFilename)) {
 			log.Warn().Msgf("Unpinning not able to remove map file : %v", mapFilename)
 			if err := os.RemoveAll(mapFilename); err != nil {
 				return fmt.Errorf("Removal of %v failed", mapFilename)

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1100,9 +1100,9 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 	for k, v := range b.ProgMapCollection.Maps {
 		var mapFilename string
 		if b.Program.ProgType == models.TCType {
-			mapFilename, _ = ValidatePath(b.hostConfig.BpfMapDefaultPath, models.TCMapPinPath, ifaceName, k)
+			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, models.TCMapPinPath, ifaceName, k)
 		} else {
-			mapFilename, _ = ValidatePath(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
+			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
 		}
 		if err := v.Unpin(); err != nil {
 			return fmt.Errorf("bpf program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",
@@ -1163,13 +1163,13 @@ func (b *BPF) VerifyCleanupMaps(chain bool) error {
 	return nil
 }
 
-func ValidatePath(filePath ...string) (string, error) {
-	destpath := ""
-	for _, x := range filePath {
-		destpath = filepath.Join(destpath, x)
-	}
-	if strings.Contains(destpath, "..") {
+func ValidatePath(filePath string, destination string) (string, error) {
+	destpath := filepath.Join(destination, filePath)
+	if strings.Contains(filePath, "..") {
 		return "", fmt.Errorf(" file contains filepath (%s) that includes (..)", filePath)
+	}
+	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%s: illegal file path", filePath)
 	}
 	return destpath, nil
 }

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1111,7 +1111,7 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 		if _, err := os.Stat(mapFilename); !os.IsNotExist(err) {
 			log.Warn().Msgf("Unpinning not able to remove map file : %v", mapFilename)
 			if err := os.RemoveAll(mapFilename); err != nil {
-				fmt.Errorf("Removal of %v failed", mapFilename)
+				return fmt.Errorf("Removal of %v failed", mapFilename)
 			}
 		}
 	}

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1108,7 +1108,7 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 			return fmt.Errorf("BPF program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",
 				b.Program.Name, b.Program.ProgType, ifaceName, mapFilename, err)
 		}
-		if _, err := os.Stat(mapFilename); !os.IsNotExist(err) {
+		if fileExists(mapFilename) {
 			log.Warn().Msgf("Unpinning not able to remove map file : %v", mapFilename)
 			if err := os.RemoveAll(mapFilename); err != nil {
 				return fmt.Errorf("Removal of %v failed", mapFilename)

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1101,8 +1101,14 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 		var mapFilename string
 		if b.Program.ProgType == models.TCType {
 			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, models.TCMapPinPath, ifaceName, k)
+			if !strings.HasPrefix(mapFilename, b.hostConfig.BpfMapDefaultPath) {
+				return fmt.Errorf("malicious mapFilename path")
+			}
 		} else {
 			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
+			if !strings.HasPrefix(mapFilename, b.hostConfig.BpfMapDefaultPath) {
+				return fmt.Errorf("malicious mapFilename path")
+			}
 		}
 		if err := v.Unpin(); err != nil {
 			return fmt.Errorf("bpf program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -1108,6 +1108,12 @@ func (b *BPF) RemoveMapFiles(ifaceName string) error {
 			return fmt.Errorf("BPF program %s prog type %s ifacename %s map %s:failed to pin the map err - %#v",
 				b.Program.Name, b.Program.ProgType, ifaceName, mapFilename, err)
 		}
+		if _, err := os.Stat(mapFilename); !os.IsNotExist(err) {
+			log.Warn().Msgf("Unpinning not able to remove map file : %v", mapFilename)
+			if err := os.RemoveAll(mapFilename); err != nil {
+				fmt.Errorf("Removal of %v failed", mapFilename)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Sometimes Unpinning the eBPF maps don't remove the files ( internally os.Remove not worked). In this PR I have added a condition when Unpinning doesn't remove the map file the we should Remove it.