### PR TITLE
Adding support for deploying programs for interfaces created on the fly

### DIFF
--- a/kf/nfconfig.go
+++ b/kf/nfconfig.go
@@ -652,10 +652,18 @@ func (c *NFConfigs) Deploy(ifaceName, HostName string, bpfProgs *models.BPFProgr
 		return errOut
 	}
 
+	var err error
 	if _, ok := c.hostInterfaces[ifaceName]; !ok {
-		errOut := fmt.Errorf("%s interface name not found in the host", ifaceName)
-		log.Error().Err(errOut)
-		return errOut
+		if c.hostInterfaces, err = getHostInterfaces(); err != nil {
+			errOut := fmt.Errorf("failed get interfaces: %v", err)
+			log.Error().Err(errOut)
+			return errOut
+		}
+		if _, interfaceFound := c.hostInterfaces[ifaceName]; !interfaceFound {
+			errOut := fmt.Errorf("%s interface name not found in the host", ifaceName)
+			log.Error().Err(errOut)
+			return errOut
+		}
 	}
 
 	c.mu.Lock()


### PR DESCRIPTION
This PR fixes the Issue: https://github.com/l3af-project/l3afd/issues/363
Adding support for deploying EBPF programs for interfaces created after L3AFD started.