### PR TITLE
Adding support for saving the logs in a specified file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// Flag to enable chaining with root program
 	BpfChainingEnabled bool
 
+	FileLogging     bool
+	FileLogLocation string
+
 	// stats
 	// Prometheus endpoint for pull/scrape the metrics.
 	MetricsAddr      string
@@ -105,6 +108,8 @@ func ReadConfig(configPath string) (*Config, error) {
 		BPFLogDir:                      LoadOptionalConfigString(confReader, "l3afd", "bpf-log-dir", ""),
 		MinKernelMajorVer:              LoadOptionalConfigInt(confReader, "l3afd", "kernel-major-version", 5),
 		MinKernelMinorVer:              LoadOptionalConfigInt(confReader, "l3afd", "kernel-minor-version", 15),
+		FileLogging:                    LoadOptionalConfigBool(confReader, "l3afd", "file-logging", false),
+		FileLogLocation:                LoadOptionalConfigString(confReader, "l3afd", "file-log-location", "l3afd.log"),
 		EBPFRepoURL:                    LoadConfigString(confReader, "ebpf-repo", "url"),
 		HttpClientTimeout:              LoadOptionalConfigDuration(confReader, "l3afd", "http-client-timeout", 30*time.Second),
 		MaxEBPFReStartCount:            LoadOptionalConfigInt(confReader, "l3afd", "max-ebpf-restart-count", 3),

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,10 @@ type Config struct {
 	// Flag to enable chaining with root program
 	BpfChainingEnabled bool
 
-	FileLogLocation string
+	FileLogLocation   string
+	FileLogMaxSize    int
+	FileLogMaxBackups int
+	FileLogMaxAge     int
 
 	// stats
 	// Prometheus endpoint for pull/scrape the metrics.
@@ -108,6 +111,9 @@ func ReadConfig(configPath string) (*Config, error) {
 		MinKernelMajorVer:              LoadOptionalConfigInt(confReader, "l3afd", "kernel-major-version", 5),
 		MinKernelMinorVer:              LoadOptionalConfigInt(confReader, "l3afd", "kernel-minor-version", 15),
 		FileLogLocation:                LoadOptionalConfigString(confReader, "l3afd", "file-log-location", ""),
+		FileLogMaxSize:                 LoadOptionalConfigInt(confReader, "l3afd", "file-log-max-size", 100),
+		FileLogMaxBackups:              LoadOptionalConfigInt(confReader, "l3afd", "file-log-max-backups", 20),
+		FileLogMaxAge:                  LoadOptionalConfigInt(confReader, "l3afd", "file-log-max-age", 60),
 		EBPFRepoURL:                    LoadConfigString(confReader, "ebpf-repo", "url"),
 		HttpClientTimeout:              LoadOptionalConfigDuration(confReader, "l3afd", "http-client-timeout", 30*time.Second),
 		MaxEBPFReStartCount:            LoadOptionalConfigInt(confReader, "l3afd", "max-ebpf-restart-count", 3),

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,6 @@ type Config struct {
 	// Flag to enable chaining with root program
 	BpfChainingEnabled bool
 
-	FileLogging     bool
 	FileLogLocation string
 
 	// stats
@@ -108,8 +107,7 @@ func ReadConfig(configPath string) (*Config, error) {
 		BPFLogDir:                      LoadOptionalConfigString(confReader, "l3afd", "bpf-log-dir", ""),
 		MinKernelMajorVer:              LoadOptionalConfigInt(confReader, "l3afd", "kernel-major-version", 5),
 		MinKernelMinorVer:              LoadOptionalConfigInt(confReader, "l3afd", "kernel-minor-version", 15),
-		FileLogging:                    LoadOptionalConfigBool(confReader, "l3afd", "file-logging", false),
-		FileLogLocation:                LoadOptionalConfigString(confReader, "l3afd", "file-log-location", "l3afd.log"),
+		FileLogLocation:                LoadOptionalConfigString(confReader, "l3afd", "file-log-location", ""),
 		EBPFRepoURL:                    LoadConfigString(confReader, "ebpf-repo", "url"),
 		HttpClientTimeout:              LoadOptionalConfigDuration(confReader, "l3afd", "http-client-timeout", 30*time.Second),
 		MaxEBPFReStartCount:            LoadOptionalConfigInt(confReader, "l3afd", "max-ebpf-restart-count", 3),

--- a/config/l3afd.cfg
+++ b/config/l3afd.cfg
@@ -14,7 +14,7 @@ swagger-api-enabled: false
 environment: PROD
 # BpfMapDefaultPath is base path for storing maps
 BpfMapDefaultPath: /sys/fs/bpf
-file-log-location: l3afd.log
+file-log-location: /var/log/l3afd.log
 
 [ebpf-repo]
 url: file:///var/l3afd/repo

--- a/config/l3afd.cfg
+++ b/config/l3afd.cfg
@@ -14,7 +14,6 @@ swagger-api-enabled: false
 environment: PROD
 # BpfMapDefaultPath is base path for storing maps
 BpfMapDefaultPath: /sys/fs/bpf
-file-logging: true
 file-log-location: l3afd.log
 
 [ebpf-repo]

--- a/config/l3afd.cfg
+++ b/config/l3afd.cfg
@@ -15,7 +15,7 @@ environment: PROD
 # BpfMapDefaultPath is base path for storing maps
 BpfMapDefaultPath: /sys/fs/bpf
 file-logging: true
-file-log-location: l3aftemp.log
+file-log-location: l3afd.log
 
 [ebpf-repo]
 url: file:///var/l3afd/repo

--- a/config/l3afd.cfg
+++ b/config/l3afd.cfg
@@ -14,7 +14,8 @@ swagger-api-enabled: false
 environment: PROD
 # BpfMapDefaultPath is base path for storing maps
 BpfMapDefaultPath: /sys/fs/bpf
-
+#file-logging: true
+file-log-location: l3aftemp.log
 
 [ebpf-repo]
 url: file:///var/l3afd/repo

--- a/config/l3afd.cfg
+++ b/config/l3afd.cfg
@@ -14,7 +14,7 @@ swagger-api-enabled: false
 environment: PROD
 # BpfMapDefaultPath is base path for storing maps
 BpfMapDefaultPath: /sys/fs/bpf
-#file-logging: true
+file-logging: true
 file-log-location: l3aftemp.log
 
 [ebpf-repo]

--- a/docs/configdoc.md
+++ b/docs/configdoc.md
@@ -2,7 +2,6 @@
 
 See [l3afd.cfg](https://github.com/l3af-project/l3afd/blob/main/config/l3afd.cfg) for a full example configuration.
 
-
 ```
 [DEFAULT]
 
@@ -23,93 +22,107 @@ environment: PROD
 
 ### Below is the detailed documentation for each field
 
-
 ## [l3afd]
 
-| FieldName     | Default                | Description     | Required        |
-| ------------- |------------------------| --------------- | --------------- |
-|pid-file| `"/var/l3afd/l3afd.pid"` | The path to the l3afd.pid file which contains process id of L3afd | Yes |
-|datacenter| `"dc"`                 | Name of Datacenter| Yes |
-|bpf-dir| `"/dev/shm"`           | Absolute Path where eBPF packages are to be extracted | Yes |
-|bpf-log-dir| `""`                   | Absolute Path for log files, which is passed to applications on the command line. L3afd does not store any logs itself.| No |
-|kernel-major-version| `"5"`                  |Major version of the kernel required to run eBPF programs (Linux Only) | No |
-|kernel-minor-version| `"1"`                  |Minor version of the kernel required to run eBPF programs (Linux Only)| No |
-|shutdown-timeout| `"1s"`                 |Maximum amount of time allowed for l3afd to gracefully stop. After shutdown-timeout, l3afd will exit even if it could not stop applications.| No |
-|http-client-timeout| `"10s"`                |Maximum amount of time allowed to get HTTP response headers when fetching a package from a repository| No |
-|max-nf-restart-count| `"3"`                  |Maximum number of tries to restart eBPF applications if they are not running| No |
-|bpf-chaining-enabled| `"true"`               |Boolean to set bpf-chaining. For more info about bpf chaining check [L3AF_KFaaS.pdf](https://github.com/l3af-project/l3af-arch/blob/main/L3AF_KFaaS.pdf)| Yes |
-|swagger-api-enabled| `"false"`              |Whether the swagger API is enabled or not.  For more info see [swagger.md](https://github.com/l3af-project/l3afd/blob/main/docs/swagger.md)| No |
-|environment| `"PROD"`               |If set to anything other than "PROD", mTLS security will not be checked| Yes |
-|BpfMapDefaultPath| `"/sys/fs/bpf"`        |The base pin path for eBPF maps| Yes |
+
+| FieldName            | Default                  | Description                                                                                                                                             | Required |
+| ---------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| pid-file             | `"/var/l3afd/l3afd.pid"` | The path to the l3afd.pid file which contains process id of L3afd                                                                                       | Yes      |
+| datacenter           | `"dc"`                   | Name of Datacenter                                                                                                                                      | Yes      |
+| bpf-dir              | `"/dev/shm"`             | Absolute Path where eBPF packages are to be extracted                                                                                                   | Yes      |
+| bpf-log-dir          | `""`                     | Absolute Path for log files, which is passed to applications on the command line. L3afd does not store any logs itself.                                 | No       |
+| kernel-major-version | `"5"`                    | Major version of the kernel required to run eBPF programs (Linux Only)                                                                                  | No       |
+| kernel-minor-version | `"1"`                    | Minor version of the kernel required to run eBPF programs (Linux Only)                                                                                  | No       |
+| shutdown-timeout     | `"1s"`                   | Maximum amount of time allowed for l3afd to gracefully stop. After shutdown-timeout, l3afd will exit even if it could not stop applications.            | No       |
+| http-client-timeout  | `"10s"`                  | Maximum amount of time allowed to get HTTP response headers when fetching a package from a repository                                                   | No       |
+| max-nf-restart-count | `"3"`                    | Maximum number of tries to restart eBPF applications if they are not running                                                                            | No       |
+| bpf-chaining-enabled | `"true"`                 | Boolean to set bpf-chaining. For more info about bpf chaining check[L3AF_KFaaS.pdf](https://github.com/l3af-project/l3af-arch/blob/main/L3AF_KFaaS.pdf) | Yes      |
+| swagger-api-enabled  | `"false"`                | Whether the swagger API is enabled or not.  For more info see[swagger.md](https://github.com/l3af-project/l3afd/blob/main/docs/swagger.md)              | No       |
+| environment          | `"PROD"`                 | If set to anything other than "PROD", mTLS security will not be checked                                                                                 | Yes      |
+| BpfMapDefaultPath    | `"/sys/fs/bpf"`          | The base pin path for eBPF maps                                                                                                                         | Yes      |
+| file-logging         | false                    | Should logs be saved to a file in addition to STDOUT                                                                                                    | No       |
+| file-log-location    | `"l3afd.log"`            | Location of the log file                                                                                                                                | No       |
 
 ## [ebpf-repo]
-| FieldName     | Default                    | Description     | Required |
-| ------------- |----------------------------| --------------- |----------|
-|url| `"file:///var/l3afd/repo"` |Default repository from which to download eBPF packages| Yes      |
+
+
+| FieldName | Default                    | Description                                             | Required |
+| ----------- | ---------------------------- | --------------------------------------------------------- | ---------- |
+| url       | `"file:///var/l3afd/repo"` | Default repository from which to download eBPF packages | Yes      |
 
 ## [web]
 
-| FieldName          | Default       | Description     | Required |
-|--------------------| ------------- | --------------- |----------|
-| metrics-addr       |`"0.0.0.0:8898"`|Prometheus endpoint for pulling/scraping the metrics.  For more info about Prometheus see [prometheus.io](https://prometheus.io/) | Yes      |
-| ebpf-poll-interval |`"30s"`|Periodic interval at which to scrape metrics using Prometheus| No       |
-| n-metric-samples   |`"20"`|Number of Metric Samples| No       |
 
+| FieldName          | Default          | Description                                                                                                                      | Required |
+| -------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| metrics-addr       | `"0.0.0.0:8898"` | Prometheus endpoint for pulling/scraping the metrics.  For more info about Prometheus see[prometheus.io](https://prometheus.io/) | Yes      |
+| ebpf-poll-interval | `"30s"`          | Periodic interval at which to scrape metrics using Prometheus                                                                    | No       |
+| n-metric-samples   | `"20"`           | Number of Metric Samples                                                                                                         | No       |
 
 ## [xdp-root]
+
 This section is needed when bpf-chaining-enabled is set to true.
 
-| FieldName           | Default                  | Description                                                              | Required        |
-|---------------------|--------------------------|--------------------------------------------------------------------------| --------------- |
-| package-name        | `"xdp-root"`             | Name of subdirectory in which to extract artifact                        | Yes |
-| artifact            | `"l3af_xdp_root.tar.gz"` | Filename of xdp-root package. Only tar.gz and .zip formats are supported | Yes |
-| ingress-map-name    | `"xdp_root_array"`       | Ingress map name of xdp-root program                                     | Yes |
-| command             | `"xdp_root"`             | Command to run xdp-root program                                          | Yes |
-| version             | `"latest"`               | Version of xdp-root program                                              | Yes |
-| object-file         | `"xdp_root_kern.o"`      | File containing the object code for xdp-root program                     | Yes |
-| entry-function-name | `"xdp_root"`             | Name of the function that begins the XDP-root program                    | Yes |
 
+| FieldName           | Default                  | Description                                                              | Required |
+| --------------------- | -------------------------- | -------------------------------------------------------------------------- | ---------- |
+| package-name        | `"xdp-root"`             | Name of subdirectory in which to extract artifact                        | Yes      |
+| artifact            | `"l3af_xdp_root.tar.gz"` | Filename of xdp-root package. Only tar.gz and .zip formats are supported | Yes      |
+| ingress-map-name    | `"xdp_root_array"`       | Ingress map name of xdp-root program                                     | Yes      |
+| command             | `"xdp_root"`             | Command to run xdp-root program                                          | Yes      |
+| version             | `"latest"`               | Version of xdp-root program                                              | Yes      |
+| object-file         | `"xdp_root_kern.o"`      | File containing the object code for xdp-root program                     | Yes      |
+| entry-function-name | `"xdp_root"`             | Name of the function that begins the XDP-root program                    | Yes      |
 
 ## [tc-root]
+
 This section is needed when bpf-chaining-enabled is set to true.
 
-| FieldName                   | Default                    | Description                                                                                                                               | Required        |
-|-----------------------------|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------| --------------- |
-| pakage-name                 | `"tc-root"`                | Name of subdirectory in which to extract artifact                                                                                         | Yes |
-| artifact                    | `"l3af_tc_root.tar.gz"`    | Filename of tc_root package                                                                                                               | Yes |
-| ingress-map-name            | `"tc_ingress_root_array"`  | Ingress map name of tc_root program                                                                                                       | Yes |
-| egress-map-name             | `"tc_egress_root_array"`   | Egress map name of tc_root program,for more info about ingress/egress check [cilium](https://docs.cilium.io/en/v1.9/concepts/ebpf/intro/) | Yes |
-| command                     | `"tc_root"`                | Command to run tc_root program                                                                                                            | Yes |
-| version                     | `"latest"`                 | Version of tc_root program                                                                                                                | Yes |
-| ingress-object-file         | `"tc_root_ingress_kern.o"` | File containing the object code for tc-root ingress program                                                                               | Yes |
-| egress-object-file          | `"tc_root_egress_kern.o"`  | File containing the object code for tc-root egress program                                                                                | Yes |
-| ingress-entry-function-name | `"tc_ingress_root"`        | Name of the function that begins the tc-root ingress program                                                                              | Yes |
-| egress-entry-function-name  | `"tc_egress_root"`         | Name of the function that begins the tc-root egress program                                                                               | Yes |
 
+| FieldName                   | Default                    | Description                                                                                                                              | Required |
+| ----------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------- |
+| pakage-name                 | `"tc-root"`                | Name of subdirectory in which to extract artifact                                                                                        | Yes      |
+| artifact                    | `"l3af_tc_root.tar.gz"`    | Filename of tc_root package                                                                                                              | Yes      |
+| ingress-map-name            | `"tc_ingress_root_array"`  | Ingress map name of tc_root program                                                                                                      | Yes      |
+| egress-map-name             | `"tc_egress_root_array"`   | Egress map name of tc_root program,for more info about ingress/egress check[cilium](https://docs.cilium.io/en/v1.9/concepts/ebpf/intro/) | Yes      |
+| command                     | `"tc_root"`                | Command to run tc_root program                                                                                                           | Yes      |
+| version                     | `"latest"`                 | Version of tc_root program                                                                                                               | Yes      |
+| ingress-object-file         | `"tc_root_ingress_kern.o"` | File containing the object code for tc-root ingress program                                                                              | Yes      |
+| egress-object-file          | `"tc_root_egress_kern.o"`  | File containing the object code for tc-root egress program                                                                               | Yes      |
+| ingress-entry-function-name | `"tc_ingress_root"`        | Name of the function that begins the tc-root ingress program                                                                             | Yes      |
+| egress-entry-function-name  | `"tc_egress_root"`         | Name of the function that begins the tc-root egress program                                                                              | Yes      |
 
 ## [ebpf-chain-debug]
+
+
 | FieldName | Default            | Description                                                    | Required |
-|-----------|--------------------|----------------------------------------------------------------|----------|
+| ----------- | -------------------- | ---------------------------------------------------------------- | ---------- |
 | addr      | `"localhost:8899"` | Hostname and Port of chaining debug REST API                   | No       |
 | enabled   | `"false"`          | Boolean to check ebpf chaining debug details is enabled or not | No       |
 
 ## [l3af-configs]
-| FieldName     | Default       | Description     | Required |
-| ------------- | ------------- | --------------- |----------|
-|restapi-addr|`"localhost:53000"`| Hostname and Port of l3af-configs REST API | No       |
+
+
+| FieldName    | Default             | Description                                | Required |
+| -------------- | --------------------- | -------------------------------------------- | ---------- |
+| restapi-addr | `"localhost:53000"` | Hostname and Port of l3af-configs REST API | No       |
 
 ## [l3af-config-store]
-| FieldName     | Default       | Description     | Required        |
-| ------------- | ------------- | --------------- | --------------- |
-|filename|`"/etc/l3afd/l3af-config.json"`|Absolute path of persistent config file where we are storing L3afBPFPrograms objects. For more info see [models](https://github.com/l3af-project/l3afd/blob/main/models/l3afd.go)| Yes |
+
+
+| FieldName | Default                         | Description                                                                                                                                                                      | Required |
+| ----------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| filename  | `"/etc/l3afd/l3af-config.json"` | Absolute path of persistent config file where we are storing L3afBPFPrograms objects. For more info see[models](https://github.com/l3af-project/l3afd/blob/main/models/l3afd.go) | Yes      |
 
 ## [mtls]
-| FieldName     | Default                            | Description                                                                                                                                                                                                                  | Required |
-| ------------- |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-|enabled| `"true"`                           | Boolean controlling whether mTLS is enabled or not on the REST API exposed by l3afd                                                                                                                                          | No       |
-|min-tls-version| `"1.3"`                            | Minimum tls version allowed                                                                                                                                                                                                  | No       |
-|cert-dir| `"/etc/l3afd/certs"`               | Absolute path of CA certificates. On Linux this points to a filesystem directory, but on Windows it can point to a [certificate store](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/certificate-stores) | No       |
-|server-crt-filename| `"server.crt"`                     | Server's ca certificate filename                                                                                                                                                                                             | No       |
-|server-key-filename| `"server.key"`                     | Server's mtls key filename                                                                                                                                                                                                   | No       |
-|cert-expiry-warning-days| `"30"`                             | How many days before expiry you want warning                                                                                                                                                                                 | No       |
-|san-match-rules| `".*l3af.l3af.io,^l3afd.l3af.io$"` | List of domain names (exact match) or regular expressions to validate client SAN DNS Names against                                                                                                                                                                  | No      |
+
+
+| FieldName                | Default                            | Description                                                                                                                                                                                                                 | Required |
+| -------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| enabled                  | `"true"`                           | Boolean controlling whether mTLS is enabled or not on the REST API exposed by l3afd                                                                                                                                         | No       |
+| min-tls-version          | `"1.3"`                            | Minimum tls version allowed                                                                                                                                                                                                 | No       |
+| cert-dir                 | `"/etc/l3afd/certs"`               | Absolute path of CA certificates. On Linux this points to a filesystem directory, but on Windows it can point to a[certificate store](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/certificate-stores) | No       |
+| server-crt-filename      | `"server.crt"`                     | Server's ca certificate filename                                                                                                                                                                                            | No       |
+| server-key-filename      | `"server.key"`                     | Server's mtls key filename                                                                                                                                                                                                  | No       |
+| cert-expiry-warning-days | `"30"`                             | How many days before expiry you want warning                                                                                                                                                                                | No       |
+| san-match-rules          | `".*l3af.l3af.io,^l3afd.l3af.io$"` | List of domain names (exact match) or regular expressions to validate client SAN DNS Names against                                                                                                                          | No       |

--- a/docs/configdoc.md
+++ b/docs/configdoc.md
@@ -42,6 +42,9 @@ environment: PROD
 |environment| `"PROD"`               |If set to anything other than "PROD", mTLS security will not be checked| Yes |
 |BpfMapDefaultPath| `"/sys/fs/bpf"`        |The base pin path for eBPF maps| Yes |
 | file-log-location | `"/var/log/l3afd.log"`            | Location of the log file | No |
+| file-log-max-size | `"100"`            | Max size in megabytes for Log file rotation | No |
+| file-log-max-backups | `"20"`            | Max size in megabytes for Log file rotation | No |
+| file-log-max-age | `"60"`            | Max number of days to keep Log files | No |
 
 ## [ebpf-repo]
 | FieldName     | Default                    | Description     | Required |

--- a/docs/configdoc.md
+++ b/docs/configdoc.md
@@ -41,7 +41,7 @@ environment: PROD
 |swagger-api-enabled| `"false"`              |Whether the swagger API is enabled or not.  For more info see [swagger.md](https://github.com/l3af-project/l3afd/blob/main/docs/swagger.md)| No |
 |environment| `"PROD"`               |If set to anything other than "PROD", mTLS security will not be checked| Yes |
 |BpfMapDefaultPath| `"/sys/fs/bpf"`        |The base pin path for eBPF maps| Yes |
-| file-log-location | `"l3afd.log"`            | Location of the log file | No |
+| file-log-location | `"/var/log/l3afd.log"`            | Location of the log file | No |
 
 ## [ebpf-repo]
 | FieldName     | Default                    | Description     | Required |

--- a/docs/configdoc.md
+++ b/docs/configdoc.md
@@ -2,6 +2,7 @@
 
 See [l3afd.cfg](https://github.com/l3af-project/l3afd/blob/main/config/l3afd.cfg) for a full example configuration.
 
+
 ```
 [DEFAULT]
 
@@ -22,107 +23,95 @@ environment: PROD
 
 ### Below is the detailed documentation for each field
 
+
 ## [l3afd]
 
-
-| FieldName            | Default                  | Description                                                                                                                                             | Required |
-| ---------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| pid-file             | `"/var/l3afd/l3afd.pid"` | The path to the l3afd.pid file which contains process id of L3afd                                                                                       | Yes      |
-| datacenter           | `"dc"`                   | Name of Datacenter                                                                                                                                      | Yes      |
-| bpf-dir              | `"/dev/shm"`             | Absolute Path where eBPF packages are to be extracted                                                                                                   | Yes      |
-| bpf-log-dir          | `""`                     | Absolute Path for log files, which is passed to applications on the command line. L3afd does not store any logs itself.                                 | No       |
-| kernel-major-version | `"5"`                    | Major version of the kernel required to run eBPF programs (Linux Only)                                                                                  | No       |
-| kernel-minor-version | `"1"`                    | Minor version of the kernel required to run eBPF programs (Linux Only)                                                                                  | No       |
-| shutdown-timeout     | `"1s"`                   | Maximum amount of time allowed for l3afd to gracefully stop. After shutdown-timeout, l3afd will exit even if it could not stop applications.            | No       |
-| http-client-timeout  | `"10s"`                  | Maximum amount of time allowed to get HTTP response headers when fetching a package from a repository                                                   | No       |
-| max-nf-restart-count | `"3"`                    | Maximum number of tries to restart eBPF applications if they are not running                                                                            | No       |
-| bpf-chaining-enabled | `"true"`                 | Boolean to set bpf-chaining. For more info about bpf chaining check[L3AF_KFaaS.pdf](https://github.com/l3af-project/l3af-arch/blob/main/L3AF_KFaaS.pdf) | Yes      |
-| swagger-api-enabled  | `"false"`                | Whether the swagger API is enabled or not.  For more info see[swagger.md](https://github.com/l3af-project/l3afd/blob/main/docs/swagger.md)              | No       |
-| environment          | `"PROD"`                 | If set to anything other than "PROD", mTLS security will not be checked                                                                                 | Yes      |
-| BpfMapDefaultPath    | `"/sys/fs/bpf"`          | The base pin path for eBPF maps                                                                                                                         | Yes      |
-| file-logging         | false                    | Should logs be saved to a file in addition to STDOUT                                                                                                    | No       |
-| file-log-location    | `"l3afd.log"`            | Location of the log file                                                                                                                                | No       |
+| FieldName     | Default                | Description     | Required        |
+| ------------- |------------------------| --------------- | --------------- |
+|pid-file| `"/var/l3afd/l3afd.pid"` | The path to the l3afd.pid file which contains process id of L3afd | Yes |
+|datacenter| `"dc"`                 | Name of Datacenter| Yes |
+|bpf-dir| `"/dev/shm"`           | Absolute Path where eBPF packages are to be extracted | Yes |
+|bpf-log-dir| `""`                   | Absolute Path for log files, which is passed to applications on the command line. L3afd does not store any logs itself.| No |
+|kernel-major-version| `"5"`                  |Major version of the kernel required to run eBPF programs (Linux Only) | No |
+|kernel-minor-version| `"1"`                  |Minor version of the kernel required to run eBPF programs (Linux Only)| No |
+|shutdown-timeout| `"1s"`                 |Maximum amount of time allowed for l3afd to gracefully stop. After shutdown-timeout, l3afd will exit even if it could not stop applications.| No |
+|http-client-timeout| `"10s"`                |Maximum amount of time allowed to get HTTP response headers when fetching a package from a repository| No |
+|max-nf-restart-count| `"3"`                  |Maximum number of tries to restart eBPF applications if they are not running| No |
+|bpf-chaining-enabled| `"true"`               |Boolean to set bpf-chaining. For more info about bpf chaining check [L3AF_KFaaS.pdf](https://github.com/l3af-project/l3af-arch/blob/main/L3AF_KFaaS.pdf)| Yes |
+|swagger-api-enabled| `"false"`              |Whether the swagger API is enabled or not.  For more info see [swagger.md](https://github.com/l3af-project/l3afd/blob/main/docs/swagger.md)| No |
+|environment| `"PROD"`               |If set to anything other than "PROD", mTLS security will not be checked| Yes |
+|BpfMapDefaultPath| `"/sys/fs/bpf"`        |The base pin path for eBPF maps| Yes |
+| file-logging| `"false"`                    | Should logs be saved to a file in addition to STDOUT | No |
+| file-log-location | `"l3afd.log"`            | Location of the log file | No |
 
 ## [ebpf-repo]
-
-
-| FieldName | Default                    | Description                                             | Required |
-| ----------- | ---------------------------- | --------------------------------------------------------- | ---------- |
-| url       | `"file:///var/l3afd/repo"` | Default repository from which to download eBPF packages | Yes      |
+| FieldName     | Default                    | Description     | Required |
+| ------------- |----------------------------| --------------- |----------|
+|url| `"file:///var/l3afd/repo"` |Default repository from which to download eBPF packages| Yes      |
 
 ## [web]
 
+| FieldName          | Default       | Description     | Required |
+|--------------------| ------------- | --------------- |----------|
+| metrics-addr       |`"0.0.0.0:8898"`|Prometheus endpoint for pulling/scraping the metrics.  For more info about Prometheus see [prometheus.io](https://prometheus.io/) | Yes      |
+| ebpf-poll-interval |`"30s"`|Periodic interval at which to scrape metrics using Prometheus| No       |
+| n-metric-samples   |`"20"`|Number of Metric Samples| No       |
 
-| FieldName          | Default          | Description                                                                                                                      | Required |
-| -------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| metrics-addr       | `"0.0.0.0:8898"` | Prometheus endpoint for pulling/scraping the metrics.  For more info about Prometheus see[prometheus.io](https://prometheus.io/) | Yes      |
-| ebpf-poll-interval | `"30s"`          | Periodic interval at which to scrape metrics using Prometheus                                                                    | No       |
-| n-metric-samples   | `"20"`           | Number of Metric Samples                                                                                                         | No       |
 
 ## [xdp-root]
-
 This section is needed when bpf-chaining-enabled is set to true.
 
+| FieldName           | Default                  | Description                                                              | Required        |
+|---------------------|--------------------------|--------------------------------------------------------------------------| --------------- |
+| package-name        | `"xdp-root"`             | Name of subdirectory in which to extract artifact                        | Yes |
+| artifact            | `"l3af_xdp_root.tar.gz"` | Filename of xdp-root package. Only tar.gz and .zip formats are supported | Yes |
+| ingress-map-name    | `"xdp_root_array"`       | Ingress map name of xdp-root program                                     | Yes |
+| command             | `"xdp_root"`             | Command to run xdp-root program                                          | Yes |
+| version             | `"latest"`               | Version of xdp-root program                                              | Yes |
+| object-file         | `"xdp_root_kern.o"`      | File containing the object code for xdp-root program                     | Yes |
+| entry-function-name | `"xdp_root"`             | Name of the function that begins the XDP-root program                    | Yes |
 
-| FieldName           | Default                  | Description                                                              | Required |
-| --------------------- | -------------------------- | -------------------------------------------------------------------------- | ---------- |
-| package-name        | `"xdp-root"`             | Name of subdirectory in which to extract artifact                        | Yes      |
-| artifact            | `"l3af_xdp_root.tar.gz"` | Filename of xdp-root package. Only tar.gz and .zip formats are supported | Yes      |
-| ingress-map-name    | `"xdp_root_array"`       | Ingress map name of xdp-root program                                     | Yes      |
-| command             | `"xdp_root"`             | Command to run xdp-root program                                          | Yes      |
-| version             | `"latest"`               | Version of xdp-root program                                              | Yes      |
-| object-file         | `"xdp_root_kern.o"`      | File containing the object code for xdp-root program                     | Yes      |
-| entry-function-name | `"xdp_root"`             | Name of the function that begins the XDP-root program                    | Yes      |
 
 ## [tc-root]
-
 This section is needed when bpf-chaining-enabled is set to true.
 
+| FieldName                   | Default                    | Description                                                                                                                               | Required        |
+|-----------------------------|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------| --------------- |
+| pakage-name                 | `"tc-root"`                | Name of subdirectory in which to extract artifact                                                                                         | Yes |
+| artifact                    | `"l3af_tc_root.tar.gz"`    | Filename of tc_root package                                                                                                               | Yes |
+| ingress-map-name            | `"tc_ingress_root_array"`  | Ingress map name of tc_root program                                                                                                       | Yes |
+| egress-map-name             | `"tc_egress_root_array"`   | Egress map name of tc_root program,for more info about ingress/egress check [cilium](https://docs.cilium.io/en/v1.9/concepts/ebpf/intro/) | Yes |
+| command                     | `"tc_root"`                | Command to run tc_root program                                                                                                            | Yes |
+| version                     | `"latest"`                 | Version of tc_root program                                                                                                                | Yes |
+| ingress-object-file         | `"tc_root_ingress_kern.o"` | File containing the object code for tc-root ingress program                                                                               | Yes |
+| egress-object-file          | `"tc_root_egress_kern.o"`  | File containing the object code for tc-root egress program                                                                                | Yes |
+| ingress-entry-function-name | `"tc_ingress_root"`        | Name of the function that begins the tc-root ingress program                                                                              | Yes |
+| egress-entry-function-name  | `"tc_egress_root"`         | Name of the function that begins the tc-root egress program                                                                               | Yes |
 
-| FieldName                   | Default                    | Description                                                                                                                              | Required |
-| ----------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------- |
-| pakage-name                 | `"tc-root"`                | Name of subdirectory in which to extract artifact                                                                                        | Yes      |
-| artifact                    | `"l3af_tc_root.tar.gz"`    | Filename of tc_root package                                                                                                              | Yes      |
-| ingress-map-name            | `"tc_ingress_root_array"`  | Ingress map name of tc_root program                                                                                                      | Yes      |
-| egress-map-name             | `"tc_egress_root_array"`   | Egress map name of tc_root program,for more info about ingress/egress check[cilium](https://docs.cilium.io/en/v1.9/concepts/ebpf/intro/) | Yes      |
-| command                     | `"tc_root"`                | Command to run tc_root program                                                                                                           | Yes      |
-| version                     | `"latest"`                 | Version of tc_root program                                                                                                               | Yes      |
-| ingress-object-file         | `"tc_root_ingress_kern.o"` | File containing the object code for tc-root ingress program                                                                              | Yes      |
-| egress-object-file          | `"tc_root_egress_kern.o"`  | File containing the object code for tc-root egress program                                                                               | Yes      |
-| ingress-entry-function-name | `"tc_ingress_root"`        | Name of the function that begins the tc-root ingress program                                                                             | Yes      |
-| egress-entry-function-name  | `"tc_egress_root"`         | Name of the function that begins the tc-root egress program                                                                              | Yes      |
 
 ## [ebpf-chain-debug]
-
-
 | FieldName | Default            | Description                                                    | Required |
-| ----------- | -------------------- | ---------------------------------------------------------------- | ---------- |
+|-----------|--------------------|----------------------------------------------------------------|----------|
 | addr      | `"localhost:8899"` | Hostname and Port of chaining debug REST API                   | No       |
 | enabled   | `"false"`          | Boolean to check ebpf chaining debug details is enabled or not | No       |
 
 ## [l3af-configs]
-
-
-| FieldName    | Default             | Description                                | Required |
-| -------------- | --------------------- | -------------------------------------------- | ---------- |
-| restapi-addr | `"localhost:53000"` | Hostname and Port of l3af-configs REST API | No       |
+| FieldName     | Default       | Description     | Required |
+| ------------- | ------------- | --------------- |----------|
+|restapi-addr|`"localhost:53000"`| Hostname and Port of l3af-configs REST API | No       |
 
 ## [l3af-config-store]
-
-
-| FieldName | Default                         | Description                                                                                                                                                                      | Required |
-| ----------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| filename  | `"/etc/l3afd/l3af-config.json"` | Absolute path of persistent config file where we are storing L3afBPFPrograms objects. For more info see[models](https://github.com/l3af-project/l3afd/blob/main/models/l3afd.go) | Yes      |
+| FieldName     | Default       | Description     | Required        |
+| ------------- | ------------- | --------------- | --------------- |
+|filename|`"/etc/l3afd/l3af-config.json"`|Absolute path of persistent config file where we are storing L3afBPFPrograms objects. For more info see [models](https://github.com/l3af-project/l3afd/blob/main/models/l3afd.go)| Yes |
 
 ## [mtls]
-
-
-| FieldName                | Default                            | Description                                                                                                                                                                                                                 | Required |
-| -------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| enabled                  | `"true"`                           | Boolean controlling whether mTLS is enabled or not on the REST API exposed by l3afd                                                                                                                                         | No       |
-| min-tls-version          | `"1.3"`                            | Minimum tls version allowed                                                                                                                                                                                                 | No       |
-| cert-dir                 | `"/etc/l3afd/certs"`               | Absolute path of CA certificates. On Linux this points to a filesystem directory, but on Windows it can point to a[certificate store](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/certificate-stores) | No       |
-| server-crt-filename      | `"server.crt"`                     | Server's ca certificate filename                                                                                                                                                                                            | No       |
-| server-key-filename      | `"server.key"`                     | Server's mtls key filename                                                                                                                                                                                                  | No       |
-| cert-expiry-warning-days | `"30"`                             | How many days before expiry you want warning                                                                                                                                                                                | No       |
-| san-match-rules          | `".*l3af.l3af.io,^l3afd.l3af.io$"` | List of domain names (exact match) or regular expressions to validate client SAN DNS Names against                                                                                                                          | No       |
+| FieldName     | Default                            | Description                                                                                                                                                                                                                  | Required |
+| ------------- |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+|enabled| `"true"`                           | Boolean controlling whether mTLS is enabled or not on the REST API exposed by l3afd                                                                                                                                          | No       |
+|min-tls-version| `"1.3"`                            | Minimum tls version allowed                                                                                                                                                                                                  | No       |
+|cert-dir| `"/etc/l3afd/certs"`               | Absolute path of CA certificates. On Linux this points to a filesystem directory, but on Windows it can point to a [certificate store](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/certificate-stores) | No       |
+|server-crt-filename| `"server.crt"`                     | Server's ca certificate filename                                                                                                                                                                                             | No       |
+|server-key-filename| `"server.key"`                     | Server's mtls key filename                                                                                                                                                                                                   | No       |
+|cert-expiry-warning-days| `"30"`                             | How many days before expiry you want warning                                                                                                                                                                                 | No       |
+|san-match-rules| `".*l3af.l3af.io,^l3afd.l3af.io$"` | List of domain names (exact match) or regular expressions to validate client SAN DNS Names against                                                                                                                                                                  | No      |

--- a/docs/configdoc.md
+++ b/docs/configdoc.md
@@ -41,7 +41,6 @@ environment: PROD
 |swagger-api-enabled| `"false"`              |Whether the swagger API is enabled or not.  For more info see [swagger.md](https://github.com/l3af-project/l3afd/blob/main/docs/swagger.md)| No |
 |environment| `"PROD"`               |If set to anything other than "PROD", mTLS security will not be checked| Yes |
 |BpfMapDefaultPath| `"/sys/fs/bpf"`        |The base pin path for eBPF maps| Yes |
-| file-logging| `"false"`                    | Should logs be saved to a file in addition to STDOUT | No |
 | file-log-location | `"l3afd.log"`            | Location of the log file | No |
 
 ## [ebpf-repo]

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 require (
 	github.com/florianl/go-tc v0.4.3
 	github.com/golang/mock v1.6.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -59,13 +59,13 @@ func setupLogging() {
 	log.Debug().Msgf("Log level set to %q", logLevel)
 }
 
-func saveLogsToFile(confFileLogLocation string) {
+func saveLogsToFile(conf *config.Config) {
 
 	logFileWithRotation := &lumberjack.Logger{
-		Filename:   confFileLogLocation,
-		MaxSize:    100, // Max size in megabytes
-		MaxBackups: 20,  // Max number of old log files to keep
-		MaxAge:     60,  // Max number of days to keep log files
+		Filename:   conf.FileLogLocation,
+		MaxSize:    conf.FileLogMaxSize,    // Max size in megabytes
+		MaxBackups: conf.FileLogMaxBackups, // Max number of old log files to keep
+		MaxAge:     conf.FileLogMaxAge,     // Max number of days to keep log files
 	}
 	multi := zerolog.MultiLevelWriter(os.Stdout, logFileWithRotation)
 	log.Logger = log.Output(zerolog.ConsoleWriter{
@@ -90,7 +90,7 @@ func main() {
 
 	if conf.FileLogLocation != "" {
 		log.Info().Msgf("Saving logs to file: %s", conf.FileLogLocation)
-		saveLogsToFile(conf.FileLogLocation)
+		saveLogsToFile(conf)
 	}
 
 	if err = pidfile.CheckPIDConflict(conf.PIDFilename); err != nil {

--- a/main.go
+++ b/main.go
@@ -59,10 +59,10 @@ func setupLogging() {
 	log.Debug().Msgf("Log level set to %q", logLevel)
 }
 
-func saveLogsToFile(conf *config.Config) {
+func saveLogsToFile(confFileLogLocation string) {
 
 	logFileWithRotation := &lumberjack.Logger{
-		Filename:   conf.FileLogLocation,
+		Filename:   confFileLogLocation,
 		MaxSize:    100, // Max size in megabytes
 		MaxBackups: 20,  // Max number of old log files to keep
 		MaxAge:     60,  // Max number of days to keep log files
@@ -91,7 +91,7 @@ func main() {
 
 	if conf.FileLogLocation != "" {
 		log.Info().Msgf("Saving logs to file: %s", conf.FileLogLocation)
-		saveLogsToFile(conf)
+		saveLogsToFile(conf.FileLogLocation)
 	}
 
 	if err = pidfile.CheckPIDConflict(conf.PIDFilename); err != nil {

--- a/main.go
+++ b/main.go
@@ -89,7 +89,8 @@ func main() {
 		log.Fatal().Err(err).Msgf("Unable to parse config %q", confPath)
 	}
 
-	if conf.FileLogging {
+	if conf.FileLogLocation != "" {
+		log.Info().Msgf("Saving logs to file: %s", conf.FileLogLocation)
 		saveLogsToFile(conf)
 	}
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,6 @@ func saveLogsToFile(confFileLogLocation string) {
 		MaxSize:    100, // Max size in megabytes
 		MaxBackups: 20,  // Max number of old log files to keep
 		MaxAge:     60,  // Max number of days to keep log files
-		Compress:   true,
 	}
 	multi := zerolog.MultiLevelWriter(os.Stdout, logFileWithRotation)
 	log.Logger = log.Output(zerolog.ConsoleWriter{


### PR DESCRIPTION
Currently, L3AFD logs are only displayed on STDOUT. However, in some usecases, the logging and metrics framework might require the logs to be saved to persistent storage or discs. This PR add the functionality of allowing user to save logs to the file as well. The file includes log-rotation by default