### PR TITLE
Fix for clearing up NF config stored withing the interface and the l3af-config-store file

### DIFF
--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -315,7 +315,7 @@ func (b *BPF) Stop(ifaceName, direction string, chain bool) error {
 
 	// unload the BPF programs
 	allInterfaces, _ := getHostInterfaces()
-	for iface, _ := range allInterfaces {
+	for iface := range allInterfaces {
 		if iface == ifaceName {
 			if b.ProgMapCollection != nil {
 				if err := b.UnloadProgram(ifaceName, direction); err != nil {

--- a/kf/bpf.go
+++ b/kf/bpf.go
@@ -314,95 +314,16 @@ func (b *BPF) Stop(ifaceName, direction string, chain bool) error {
 	}
 
 	// unload the BPF programs
-	if b.ProgMapCollection != nil {
-		if err := b.UnloadProgram(ifaceName, direction); err != nil {
-			return fmt.Errorf("BPFProgram %s unload failed on interface %s with error: %w", b.Program.Name, ifaceName, err)
-		}
-		log.Info().Msgf("%s => %s direction => %s - program is unloaded/detached successfully", ifaceName, b.Program.Name, direction)
-	}
-	if err := b.VerifyCleanupMaps(chain); err != nil {
-		log.Error().Err(err).Msgf("stop user program - failed to remove map files %s", b.Program.Name)
-		return fmt.Errorf("stop user program - failed to remove map files %s", b.Program.Name)
-	}
-
-	return nil
-}
-
-// CleanupForDeletedInterface returns the last error seen
-// Stops the user programs if any
-// Clean up all map handles.
-// Verify next program pinned map file is removed
-func (b *BPF) CleanupForDeletedInterface(ifaceName, direction string, chain bool) error {
-	if b.Program.UserProgramDaemon && b.Cmd == nil {
-		return fmt.Errorf("BPFProgram is not running %s", b.Program.Name)
-	}
-
-	log.Info().Msgf("Stopping BPF Program 1 - %s", b.Program.Name)
-
-	// Removing maps
-	for key, val := range b.BpfMaps {
-		log.Debug().Msgf("removing BPF maps %s value map %#v", key, val)
-		delete(b.BpfMaps, key)
-	}
-
-	// Removing Metrics maps
-	for key, val := range b.MetricsBpfMaps {
-		log.Debug().Msgf("removing metric bpf maps %s value %#v", key, val)
-		delete(b.MetricsBpfMaps, key)
-	}
-
-	// Stop KFconfigs
-	if len(b.Program.CmdConfig) > 0 && len(b.Program.ConfigFilePath) > 0 {
-		log.Info().Msgf("Stopping KF configs %s ", b.Program.Name)
-		b.Done <- true
-	}
-
-	// Reset ProgID
-	b.ProgID = 0
-
-	stats.Incr(stats.BPFStopCount, b.Program.Name, direction, ifaceName)
-
-	// Setting NFRunning to 0, indicates not running
-	stats.SetWithVersion(0.0, stats.BPFRunning, b.Program.Name, b.Program.Version, direction, ifaceName)
-	// Stop User Programs if any
-	if len(b.Program.CmdStop) < 1 && b.Program.UserProgramDaemon {
-		// Loaded using user program
-		if err := b.ProcessTerminate(); err != nil {
-			return fmt.Errorf("BPFProgram %s process terminate failed with error: %w", b.Program.Name, err)
-		}
-		if b.Cmd != nil {
-			if err := b.Cmd.Wait(); err != nil {
-				log.Error().Err(err).Msgf("cmd wait at stopping bpf program %s errored", b.Program.Name)
-			}
-			b.Cmd = nil
-		}
-	} else if len(b.Program.CmdStop) > 0 && b.Program.UserProgramDaemon {
-		cmd := filepath.Join(b.FilePath, b.Program.CmdStop)
-
-		if err := assertExecutable(cmd); err != nil {
-			return fmt.Errorf("no executable permissions on %s - error %w", b.Program.CmdStop, err)
-		}
-
-		args := make([]string, 0, len(b.Program.StopArgs)<<1)
-		args = append(args, "--iface="+ifaceName)     // detaching from iface
-		args = append(args, "--direction="+direction) // xdpingress or ingress or egress
-
-		for k, val := range b.Program.StopArgs {
-			if v, ok := val.(string); !ok {
-				err := fmt.Errorf("stop args is not a string for the bpf program %s", b.Program.Name)
-				log.Error().Err(err).Msgf("failed to convert stop args value into string for program %s", b.Program.Name)
-				return err
-			} else {
-				args = append(args, "--"+k+" ="+v)
+	allInterfaces, _ := getHostInterfaces()
+	for iface, _ := range allInterfaces {
+		if iface == ifaceName {
+			if b.ProgMapCollection != nil {
+				if err := b.UnloadProgram(ifaceName, direction); err != nil {
+					return fmt.Errorf("BPFProgram %s unload failed on interface %s with error: %w", b.Program.Name, ifaceName, err)
+				}
+				log.Info().Msgf("%s => %s direction => %s - program is unloaded/detached successfully", ifaceName, b.Program.Name, direction)
 			}
 		}
-
-		log.Info().Msgf("bpf program stop command : %s %v", cmd, args)
-		prog := execCommand(cmd, args...)
-		if err := prog.Run(); err != nil {
-			log.Warn().Err(err).Msgf("l3afd : Failed to stop the program %s", b.Program.CmdStop)
-		}
-		b.Cmd = nil
 	}
 
 	if err := b.RemoveMapFiles(ifaceName); err != nil {
@@ -1191,16 +1112,18 @@ func (b *BPF) UnloadProgram(ifaceName, direction string) error {
 
 // RemoveMapFiles - removes all the pinned map files
 func (b *BPF) RemoveMapFiles(ifaceName string) error {
-	for k, v := range b.ProgMapCollection.Maps {
-		var mapFilename string
-		if b.Program.ProgType == models.TCType {
-			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, models.TCMapPinPath, ifaceName, k)
-		} else {
-			mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
-		}
-		if err := v.Unpin(); err != nil {
-			return fmt.Errorf("BPF program %s prog type %s ifacename %s map %s:failed to pin the map err - %w",
-				b.Program.Name, b.Program.ProgType, ifaceName, mapFilename, err)
+	if b.ProgMapCollection != nil {
+		for k, v := range b.ProgMapCollection.Maps {
+			var mapFilename string
+			if b.Program.ProgType == models.TCType {
+				mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, models.TCMapPinPath, ifaceName, k)
+			} else {
+				mapFilename = filepath.Join(b.hostConfig.BpfMapDefaultPath, ifaceName, k)
+			}
+			if err := v.Unpin(); err != nil {
+				return fmt.Errorf("BPF program %s prog type %s ifacename %s map %s:failed to pin the map err - %w",
+					b.Program.Name, b.Program.ProgType, ifaceName, mapFilename, err)
+			}
 		}
 	}
 	return nil

--- a/kf/nfconfig.go
+++ b/kf/nfconfig.go
@@ -651,12 +651,8 @@ func (c *NFConfigs) Deploy(ifaceName, HostName string, bpfProgs *models.BPFProgr
 		return errOut
 	}
 
-	var err error
 	if _, ok := c.hostInterfaces[ifaceName]; !ok {
-		err = c.CleanupProgramsOnInterface(ifaceName)
-		if err != nil {
-			return fmt.Errorf("CleanupProgramsOnInterface function failed : %w", err)
-		}
+		c.CleanupProgramsOnInterface(ifaceName)
 		errOut := fmt.Errorf("%s interface name not found in the host Stop called", ifaceName)
 		log.Error().Err(errOut)
 		return errOut
@@ -1189,7 +1185,7 @@ func (c *NFConfigs) AddeBPFPrograms(bpfProgs []models.L3afBPFPrograms) error {
 }
 
 // CleanupProgramsOnInterface removes all EBPF program and its metadata, on the network interface provided
-func (c *NFConfigs) CleanupProgramsOnInterface(ifaceName string) error {
+func (c *NFConfigs) CleanupProgramsOnInterface(ifaceName string) {
 	if c.IngressXDPBpfs[ifaceName] != nil {
 		if err := c.StopNRemoveAllBPFPrograms(ifaceName, models.XDPIngressType); err != nil {
 			log.Warn().Err(err).Msg("failed to Close Ingress XDP BPF Program")
@@ -1205,7 +1201,6 @@ func (c *NFConfigs) CleanupProgramsOnInterface(ifaceName string) error {
 			log.Warn().Err(err).Msg("failed to Close Ingress XDP BPF Program")
 		}
 	}
-	return nil
 }
 
 // DeleteProgramsOnInterface : It will delete ebpf Programs on the given interface
@@ -1230,10 +1225,7 @@ func (c *NFConfigs) DeleteProgramsOnInterface(ifaceName, HostName string, bpfPro
 	}
 
 	if _, ok := c.hostInterfaces[ifaceName]; !ok {
-		err = c.CleanupProgramsOnInterface(ifaceName)
-		if err != nil {
-			return fmt.Errorf("CleanupProgramsOnInterface function failed : %w", err)
-		}
+		c.CleanupProgramsOnInterface(ifaceName)
 		errOut := fmt.Errorf("%s interface name not found in the host, Stop called, %w", ifaceName, err)
 		log.Error().Err(errOut)
 		return errOut

--- a/kf/nfconfig.go
+++ b/kf/nfconfig.go
@@ -1244,36 +1244,20 @@ func (c *NFConfigs) DeleteProgramsOnInterface(ifaceName, HostName string, bpfPro
 	}
 
 	if _, ok := c.hostInterfaces[ifaceName]; !ok {
-		var bpfList *list.List
-		if c.EgressTCBpfs[ifaceName] != nil {
-			bpfList = c.EgressTCBpfs[ifaceName]
-			for e := bpfList.Front(); e != nil; e = e.Next() {
-				data := e.Value.(*BPF)
-				if err := data.Stop(ifaceName, models.EgressType, c.HostConfig.BpfChainingEnabled); err != nil {
-					log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
-				}
+		if c.IngressXDPBpfs[ifaceName] != nil {
+			if err := c.StopNRemoveAllBPFPrograms(ifaceName, models.XDPIngressType); err != nil {
+				log.Warn().Err(err).Msg("failed to Close Ingress XDP BPF Program")
 			}
-			c.EgressTCBpfs[ifaceName] = nil
 		}
 		if c.IngressTCBpfs[ifaceName] != nil {
-			bpfList = c.IngressTCBpfs[ifaceName]
-			for e := bpfList.Front(); e != nil; e = e.Next() {
-				data := e.Value.(*BPF)
-				if err := data.Stop(ifaceName, models.IngressType, c.HostConfig.BpfChainingEnabled); err != nil {
-					log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
-				}
+			if err := c.StopNRemoveAllBPFPrograms(ifaceName, models.IngressType); err != nil {
+				log.Warn().Err(err).Msg("failed to Close Ingress XDP BPF Program")
 			}
-			c.IngressTCBpfs[ifaceName] = nil
 		}
-		if c.IngressXDPBpfs[ifaceName] != nil {
-			bpfList = c.IngressXDPBpfs[ifaceName]
-			for e := bpfList.Front(); e != nil; e = e.Next() {
-				data := e.Value.(*BPF)
-				if err := data.Stop(ifaceName, models.XDPIngressType, c.HostConfig.BpfChainingEnabled); err != nil {
-					log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
-				}
+		if c.EgressTCBpfs[ifaceName] != nil {
+			if err := c.StopNRemoveAllBPFPrograms(ifaceName, models.EgressType); err != nil {
+				log.Warn().Err(err).Msg("failed to Close Ingress XDP BPF Program")
 			}
-			c.IngressXDPBpfs[ifaceName] = nil
 		}
 		errOut := fmt.Errorf("%s interface name not found in the host, Stop called ", ifaceName)
 		log.Error().Err(errOut)

--- a/kf/nfconfig.go
+++ b/kf/nfconfig.go
@@ -664,7 +664,7 @@ func (c *NFConfigs) Deploy(ifaceName, HostName string, bpfProgs *models.BPFProgr
 				bpfList = c.EgressTCBpfs[ifaceName]
 				for e := bpfList.Front(); e != nil; e = e.Next() {
 					data := e.Value.(*BPF)
-					if err := data.CleanupForDeletedInterface(ifaceName, models.EgressType, c.HostConfig.BpfChainingEnabled); err != nil {
+					if err := data.Stop(ifaceName, models.EgressType, c.HostConfig.BpfChainingEnabled); err != nil {
 						log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
 					}
 				}
@@ -674,7 +674,7 @@ func (c *NFConfigs) Deploy(ifaceName, HostName string, bpfProgs *models.BPFProgr
 				bpfList = c.IngressTCBpfs[ifaceName]
 				for e := bpfList.Front(); e != nil; e = e.Next() {
 					data := e.Value.(*BPF)
-					if err := data.CleanupForDeletedInterface(ifaceName, models.IngressType, c.HostConfig.BpfChainingEnabled); err != nil {
+					if err := data.Stop(ifaceName, models.IngressType, c.HostConfig.BpfChainingEnabled); err != nil {
 						log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
 					}
 				}
@@ -684,13 +684,13 @@ func (c *NFConfigs) Deploy(ifaceName, HostName string, bpfProgs *models.BPFProgr
 				bpfList = c.IngressXDPBpfs[ifaceName]
 				for e := bpfList.Front(); e != nil; e = e.Next() {
 					data := e.Value.(*BPF)
-					if err := data.CleanupForDeletedInterface(ifaceName, models.XDPIngressType, c.HostConfig.BpfChainingEnabled); err != nil {
+					if err := data.Stop(ifaceName, models.XDPIngressType, c.HostConfig.BpfChainingEnabled); err != nil {
 						log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
 					}
 				}
 				c.IngressXDPBpfs[ifaceName] = nil
 			}
-			errOut := fmt.Errorf("%s interface name not found in the host CleanupForDeletedInterface called", ifaceName)
+			errOut := fmt.Errorf("%s interface name not found in the host Stop called", ifaceName)
 			log.Error().Err(errOut)
 			return errOut
 		}
@@ -1275,7 +1275,7 @@ func (c *NFConfigs) DeleteProgramsOnInterface(ifaceName, HostName string, bpfPro
 			}
 			c.IngressXDPBpfs[ifaceName] = nil
 		}
-		errOut := fmt.Errorf("%s interface name not found in the host, CleanupForDeletedInterface called ", ifaceName)
+		errOut := fmt.Errorf("%s interface name not found in the host, Stop called ", ifaceName)
 		log.Error().Err(errOut)
 		return errOut
 	}

--- a/kf/nfconfig.go
+++ b/kf/nfconfig.go
@@ -365,7 +365,6 @@ func (c *NFConfigs) VerifyNUpdateBPFProgram(bpfProg *models.BPFProgram, ifaceNam
 		// Version Change
 		if data.Program.Version != bpfProg.Version || !reflect.DeepEqual(data.Program.StartArgs, bpfProg.StartArgs) {
 			log.Info().Msgf("VerifyNUpdateBPFProgram : version update initiated - current version %s new version %s", data.Program.Version, bpfProg.Version)
-
 			if err := data.Stop(ifaceName, direction, c.HostConfig.BpfChainingEnabled); err != nil {
 				return fmt.Errorf("failed to stop older version of network function BPF %s iface %s direction %s version %s with err: %w", bpfProg.Name, ifaceName, direction, bpfProg.Version, err)
 			}
@@ -1250,7 +1249,7 @@ func (c *NFConfigs) DeleteProgramsOnInterface(ifaceName, HostName string, bpfPro
 			bpfList = c.EgressTCBpfs[ifaceName]
 			for e := bpfList.Front(); e != nil; e = e.Next() {
 				data := e.Value.(*BPF)
-				if err := data.CleanupForDeletedInterface(ifaceName, models.EgressType, c.HostConfig.BpfChainingEnabled); err != nil {
+				if err := data.Stop(ifaceName, models.EgressType, c.HostConfig.BpfChainingEnabled); err != nil {
 					log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
 				}
 			}
@@ -1260,7 +1259,7 @@ func (c *NFConfigs) DeleteProgramsOnInterface(ifaceName, HostName string, bpfPro
 			bpfList = c.IngressTCBpfs[ifaceName]
 			for e := bpfList.Front(); e != nil; e = e.Next() {
 				data := e.Value.(*BPF)
-				if err := data.CleanupForDeletedInterface(ifaceName, models.IngressType, c.HostConfig.BpfChainingEnabled); err != nil {
+				if err := data.Stop(ifaceName, models.IngressType, c.HostConfig.BpfChainingEnabled); err != nil {
 					log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
 				}
 			}
@@ -1270,7 +1269,7 @@ func (c *NFConfigs) DeleteProgramsOnInterface(ifaceName, HostName string, bpfPro
 			bpfList = c.IngressXDPBpfs[ifaceName]
 			for e := bpfList.Front(); e != nil; e = e.Next() {
 				data := e.Value.(*BPF)
-				if err := data.CleanupForDeletedInterface(ifaceName, models.XDPIngressType, c.HostConfig.BpfChainingEnabled); err != nil {
+				if err := data.Stop(ifaceName, models.XDPIngressType, c.HostConfig.BpfChainingEnabled); err != nil {
 					log.Error().Err(err).Msgf("failed to remove map file for program %s => %s", ifaceName, data.Program.Name)
 				}
 			}

--- a/kf/nfconfig_test.go
+++ b/kf/nfconfig_test.go
@@ -761,7 +761,7 @@ func TestDeleteProgramsOnInterface(t *testing.T) {
 			wanterr: true,
 		},
 		{
-			name: "GoodInput",
+			name: "GoodInputButNotRealInterface",
 			field: fields{
 				hostName:       "l3af-local-test",
 				hostInterfaces: map[string]bool{"fakeif0": true},
@@ -779,7 +779,7 @@ func TestDeleteProgramsOnInterface(t *testing.T) {
 					TCEgress:   []string{},
 				},
 			},
-			wanterr: false,
+			wanterr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -887,7 +887,7 @@ func TestDeleteEbpfPrograms(t *testing.T) {
 			wanterr: true,
 		},
 		{
-			name: "GoodInput",
+			name: "GoodInputButNotRealInterface",
 			field: fields{
 				hostName:       "l3af-local-test",
 				hostInterfaces: map[string]bool{"fakeif0": true},
@@ -911,7 +911,7 @@ func TestDeleteEbpfPrograms(t *testing.T) {
 					},
 				},
 			},
-			wanterr: false,
+			wanterr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- When an interface is deleted on the fly, and a delete/remove call is received for the that interface, all the programs associated with that interface should be deleted. Hence, in the PR, on receiving a delete call for an unloaded-interface, the local copy of the programs stored in go-interface and the l3af-config-store file is deleted for cleanup