### PR TITLE
Add interfaces instead of overwritting in L3AFd

### DIFF
--- a/kf/nfconfig.go
+++ b/kf/nfconfig.go
@@ -651,6 +651,7 @@ func (c *NFConfigs) Deploy(ifaceName, HostName string, bpfProgs *models.BPFProgr
 		return errOut
 	}
 
+	c.hostInterfaces, _ = getHostInterfaces()
 	if _, ok := c.hostInterfaces[ifaceName]; !ok {
 		c.CleanupProgramsOnInterface(ifaceName)
 		errOut := fmt.Errorf("%s interface name not found in the host Stop called", ifaceName)
@@ -725,7 +726,11 @@ func (c *NFConfigs) DeployeBPFPrograms(bpfProgs []models.L3afBPFPrograms) error 
 			}
 			return fmt.Errorf("failed to deploy BPF program on iface %s with error: %w", bpfProg.Iface, err)
 		}
-		c.ifaces = map[string]string{bpfProg.Iface: bpfProg.Iface}
+		if len(c.ifaces) == 0 {
+			c.ifaces = map[string]string{bpfProg.Iface: bpfProg.Iface}
+		} else {
+			c.ifaces[bpfProg.Iface] = bpfProg.Iface
+		}
 	}
 
 	if err := c.RemoveMissingNetIfacesNBPFProgsInConfig(bpfProgs); err != nil {
@@ -820,7 +825,6 @@ func (c *NFConfigs) EBPFProgramsAll() []models.L3afBPFPrograms {
 
 // RemoveMissingNetIfacesNBPFProgsInConfig - Stops running eBPF programs which are missing in the config
 func (c *NFConfigs) RemoveMissingNetIfacesNBPFProgsInConfig(bpfProgCfgs []models.L3afBPFPrograms) error {
-
 	tempIfaces := map[string]bool{}
 	wg := sync.WaitGroup{}
 	for _, bpfProg := range bpfProgCfgs {
@@ -881,7 +885,6 @@ func (c *NFConfigs) RemoveMissingNetIfacesNBPFProgsInConfig(bpfProgCfgs []models
 
 // RemoveMissingBPFProgramsInConfig - This method to stop the eBPF programs which are not listed in the config.
 func (c *NFConfigs) RemoveMissingBPFProgramsInConfig(bpfProg models.L3afBPFPrograms, ifaceName, direction string) error {
-
 	var bpfProgArr []*models.BPFProgram
 	var bpfList *list.List
 	switch direction {
@@ -1093,6 +1096,7 @@ func (c *NFConfigs) AddProgramsOnInterface(ifaceName, HostName string, bpfProgs 
 		return errOut
 	}
 
+	c.hostInterfaces, _ = getHostInterfaces()
 	if _, ok := c.hostInterfaces[ifaceName]; !ok {
 		errOut := fmt.Errorf("%s interface name not found in the host", ifaceName)
 		log.Error().Err(errOut)
@@ -1176,7 +1180,11 @@ func (c *NFConfigs) AddeBPFPrograms(bpfProgs []models.L3afBPFPrograms) error {
 			}
 			return fmt.Errorf("failed to Add BPF program on iface %s with error: %w", bpfProg.Iface, err)
 		}
-		c.ifaces = map[string]string{bpfProg.Iface: bpfProg.Iface}
+		if len(c.ifaces) == 0 {
+			c.ifaces = map[string]string{bpfProg.Iface: bpfProg.Iface}
+		} else {
+			c.ifaces[bpfProg.Iface] = bpfProg.Iface
+		}
 	}
 	if err := c.SaveConfigsToConfigStore(); err != nil {
 		return fmt.Errorf("AddeBPFPrograms failed to save configs %w", err)

--- a/kf/nfconfig_test.go
+++ b/kf/nfconfig_test.go
@@ -205,7 +205,9 @@ func TestNFConfigs_Deploy(t *testing.T) {
 		log.Info().Msg("getHostInterfaces returned and error")
 	}
 	var hostInterfacesKey string
-	for hostInterfacesKey, _ = range hostInterfaces {
+	var hostInterfacesValue bool
+	for hostInterfacesKey, hostInterfacesValue = range hostInterfaces {
+		log.Debug().Msgf("hostInterfacesKey: %v, hostInterfacesValue: %v", hostInterfacesKey, hostInterfacesValue)
 		break
 	}
 	tests := []struct {
@@ -467,7 +469,9 @@ func Test_AddProgramsOnInterface(t *testing.T) {
 		log.Info().Msg("getHostInterfaces returned and error")
 	}
 	var hostInterfacesKey string
-	for hostInterfacesKey, _ = range hostInterfaces {
+	var hostInterfacesValue bool
+	for hostInterfacesKey, hostInterfacesValue = range hostInterfaces {
+		log.Debug().Msgf("hostInterfacesKey: %v, hostInterfacesValue: %v", hostInterfacesKey, hostInterfacesValue)
 		break
 	}
 	type fields struct {
@@ -585,7 +589,9 @@ func TestAddeBPFPrograms(t *testing.T) {
 		log.Info().Msg("getHostInterfaces returned and error")
 	}
 	var hostInterfacesKey string
-	for hostInterfacesKey, _ = range hostInterfaces {
+	var hostInterfacesValue bool
+	for hostInterfacesKey, hostInterfacesValue = range hostInterfaces {
+		log.Debug().Msgf("hostInterfacesKey: %v, hostInterfacesValue: %v", hostInterfacesKey, hostInterfacesValue)
 		break
 	}
 	type fields struct {

--- a/kf/nfconfig_test.go
+++ b/kf/nfconfig_test.go
@@ -200,7 +200,10 @@ func TestNFConfigs_Deploy(t *testing.T) {
 	setupBPFProgramVersionChange()
 	setupBPFProgramStatusChange()
 
-	hostInterfaces, _ = getHostInterfaces()
+	hostInterfaces, err := getHostInterfaces()
+	if err != nil {
+		log.Info().Msg("getHostInterfaces returned and error")
+	}
 	var hostInterfacesKey string
 	for hostInterfacesKey, _ = range hostInterfaces {
 		break
@@ -459,7 +462,10 @@ func Test_BinarySearch(t *testing.T) {
 }
 
 func Test_AddProgramsOnInterface(t *testing.T) {
-	hostInterfaces, _ = getHostInterfaces()
+	hostInterfaces, err := getHostInterfaces()
+	if err != nil {
+		log.Info().Msg("getHostInterfaces returned and error")
+	}
 	var hostInterfacesKey string
 	for hostInterfacesKey, _ = range hostInterfaces {
 		break
@@ -574,7 +580,10 @@ func Test_AddProgramsOnInterface(t *testing.T) {
 }
 
 func TestAddeBPFPrograms(t *testing.T) {
-	hostInterfaces, _ = getHostInterfaces()
+	hostInterfaces, err := getHostInterfaces()
+	if err != nil {
+		log.Info().Msg("getHostInterfaces returned and error")
+	}
 	var hostInterfacesKey string
 	for hostInterfacesKey, _ = range hostInterfaces {
 		break

--- a/kf/nfconfig_test.go
+++ b/kf/nfconfig_test.go
@@ -200,6 +200,11 @@ func TestNFConfigs_Deploy(t *testing.T) {
 	setupBPFProgramVersionChange()
 	setupBPFProgramStatusChange()
 
+	hostInterfaces, _ = getHostInterfaces()
+	var hostInterfacesKey string
+	for hostInterfacesKey, _ = range hostInterfaces {
+		break
+	}
 	tests := []struct {
 		name    string
 		fields  fields
@@ -264,7 +269,7 @@ func TestNFConfigs_Deploy(t *testing.T) {
 			name: "ValidHostNameValidIfaceName",
 			fields: fields{
 				hostName:       machineHostname,
-				hostInterfaces: map[string]bool{"fakeif0": true},
+				hostInterfaces: hostInterfaces,
 				ingressXDPBpfs: make(map[string]*list.List),
 				ingressTCBpfs:  make(map[string]*list.List),
 				egressTCBpfs:   make(map[string]*list.List),
@@ -273,7 +278,7 @@ func TestNFConfigs_Deploy(t *testing.T) {
 				metricsMon:     mMon,
 			},
 			args: args{
-				iface:    "fakeif0",
+				iface:    hostInterfacesKey,
 				hostName: machineHostname,
 				bpfProgs: &models.BPFPrograms{},
 			},
@@ -283,7 +288,7 @@ func TestNFConfigs_Deploy(t *testing.T) {
 			name: "TestEBPFRepoDownload",
 			fields: fields{
 				hostName:       machineHostname,
-				hostInterfaces: map[string]bool{"fakeif0": true},
+				hostInterfaces: hostInterfaces,
 				ingressXDPBpfs: make(map[string]*list.List),
 				ingressTCBpfs:  make(map[string]*list.List),
 				egressTCBpfs:   make(map[string]*list.List),
@@ -292,7 +297,7 @@ func TestNFConfigs_Deploy(t *testing.T) {
 				metricsMon:     mMon,
 			},
 			args: args{
-				iface:    "fakeif0",
+				iface:    hostInterfacesKey,
 				hostName: machineHostname,
 				bpfProgs: bpfProgs,
 			},
@@ -302,7 +307,7 @@ func TestNFConfigs_Deploy(t *testing.T) {
 			name: "NewBPFWithVersionChange",
 			fields: fields{
 				hostName:       machineHostname,
-				hostInterfaces: map[string]bool{"fakeif0": true},
+				hostInterfaces: hostInterfaces,
 				ingressXDPBpfs: make(map[string]*list.List),
 				ingressTCBpfs:  make(map[string]*list.List),
 				egressTCBpfs:   make(map[string]*list.List),
@@ -311,7 +316,7 @@ func TestNFConfigs_Deploy(t *testing.T) {
 				metricsMon:     mMon,
 			},
 			args: args{
-				iface:    "fakeif0",
+				iface:    hostInterfacesKey,
 				hostName: machineHostname,
 				bpfProgs: valVerChange,
 			},
@@ -321,7 +326,7 @@ func TestNFConfigs_Deploy(t *testing.T) {
 			name: "NewBPFWithStatusChange",
 			fields: fields{
 				hostName:       machineHostname,
-				hostInterfaces: map[string]bool{"fakeif0": true},
+				hostInterfaces: hostInterfaces,
 				ingressXDPBpfs: make(map[string]*list.List),
 				ingressTCBpfs:  make(map[string]*list.List),
 				egressTCBpfs:   make(map[string]*list.List),
@@ -330,7 +335,7 @@ func TestNFConfigs_Deploy(t *testing.T) {
 				metricsMon:     mMon,
 			},
 			args: args{
-				iface:    "fakeif0",
+				iface:    hostInterfacesKey,
 				hostName: machineHostname,
 				bpfProgs: valStatusChange,
 			},
@@ -454,6 +459,11 @@ func Test_BinarySearch(t *testing.T) {
 }
 
 func Test_AddProgramsOnInterface(t *testing.T) {
+	hostInterfaces, _ = getHostInterfaces()
+	var hostInterfacesKey string
+	for hostInterfacesKey, _ = range hostInterfaces {
+		break
+	}
 	type fields struct {
 		hostName       string
 		hostInterfaces map[string]bool
@@ -522,7 +532,7 @@ func Test_AddProgramsOnInterface(t *testing.T) {
 			name: "GoodInput",
 			field: fields{
 				hostName:       "l3af-local-test",
-				hostInterfaces: map[string]bool{"fakeif0": true},
+				hostInterfaces: hostInterfaces,
 				mu:             new(sync.Mutex),
 				ingressXDPBpfs: map[string]*list.List{"fakeif0": nil},
 				ingressTCBpfs:  map[string]*list.List{"fakeif0": nil},
@@ -533,7 +543,7 @@ func Test_AddProgramsOnInterface(t *testing.T) {
 			},
 			arg: args{
 				hostName: "l3af-local-test",
-				iface:    "fakeif0",
+				iface:    hostInterfacesKey,
 				bpfProgs: &models.BPFPrograms{
 					XDPIngress: []*models.BPFProgram{},
 					TCEgress:   []*models.BPFProgram{},
@@ -564,6 +574,11 @@ func Test_AddProgramsOnInterface(t *testing.T) {
 }
 
 func TestAddeBPFPrograms(t *testing.T) {
+	hostInterfaces, _ = getHostInterfaces()
+	var hostInterfacesKey string
+	for hostInterfacesKey, _ = range hostInterfaces {
+		break
+	}
 	type fields struct {
 		hostName       string
 		hostInterfaces map[string]bool
@@ -661,7 +676,7 @@ func TestAddeBPFPrograms(t *testing.T) {
 			name: "GoodInput",
 			field: fields{
 				hostName:       "l3af-local-test",
-				hostInterfaces: map[string]bool{"fakeif0": true},
+				hostInterfaces: hostInterfaces,
 				// fakeif0 is a fake interface
 				mu:             new(sync.Mutex),
 				ingressXDPBpfs: map[string]*list.List{"fakeif0": nil},
@@ -675,7 +690,7 @@ func TestAddeBPFPrograms(t *testing.T) {
 			arg: []models.L3afBPFPrograms{
 				{
 					HostName: "l3af-local-test",
-					Iface:    "fakeif0",
+					Iface:    hostInterfacesKey,
 					BpfPrograms: &models.BPFPrograms{
 						XDPIngress: []*models.BPFProgram{},
 						TCIngress:  []*models.BPFProgram{},


### PR DESCRIPTION
Internal L3AFD state maintaining the list of interfaces in c.ifaces was getting overwritten in case of update call. These changes especially are relevant when we have NFconfigs for multiple interfaces on the same host. In that case when the NFconfigs for the second interface is added, the c.ifaces variable maintained by L3AFd will be overwritten by the second interface. Instead, these changes add the second and following interface to the map.