### PR TITLE
Running L3AFD in a Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,21 @@ For Windows:
 cmake -B build
 cmake --build build
 ```
+# Docker build
+- L3AFD binary & configuration that is required in the Docker image needs to be built locally and copied to build-docker directory
+- Execute below command to build the docker image
+```
+docker build -t l3afd:r2 -f Dockerfile.l3afd .
+```
+Requirements to run L3AFD as a Container
+- BPF, debugfs & shared-memory filesystems mount points should be available in the container
+- L3AFD container needs privileged access as it needs to manage eBPF programs
+- eBPF programs should be attached to the host interface so that it will apply to all the containers in the host
 
+In order to satisfy the above requirements L3afd docker container needs to be run using the below command
+```
+docker run -d -v /sys/fs/bpf:/sys/fs/bpf -v /sys/kernel/debug/:/sys/kernel/debug/ -v /dev/shm:/dev/shm --privileged --net=host l3afd:r2
+```
 # Testing
 To test on your local machine, do the following.
 
@@ -59,35 +73,6 @@ go test -tags WINDOWS ./...
 
 # Generate Swagger Docs
 See our [Swaggo setup](docs/swagger.md)
-
-# Build L3AFD Docker image
-- L3afd binary & configuration that is required in the Docker image needs to be built locally and copied to build-docker directory
-- Execute below command to build the docker image 
-```
-docker build -t l3afd:r2 -f Dockerfile.l3afd .
-```
-Note: l3afd:r2 => <docker-build-name>:<tag> Name and build tag can be changed accordingly
-
-# Run L3AFD Docker Container 
-Requirements to run L3afd as a Container
-- BPF, debugfs & shared-memory filesystems mount points should be available in the Container
-- L3afd container needs Privileged access as it needs to perform attach/detach of eBPF programs
-- eBPF programs should be attached to the Host interface so that it will apply to all the Containers in the Host
-
-In order to satisfy the above requirements L3afd docker container needs to be run using the below command
-```
-docker run -d -v /sys/fs/bpf:/sys/fs/bpf -v /sys/kernel/debug/:/sys/kernel/debug/ -v /dev/shm:/dev/shm --privileged --net=host l3afd:r2
-```
-
-Command to connect to L3afd container shell
-```
-docker exec -it <container> /bin/bashL3afd logs
-```
-
-Command to check L3afd logs
-```
-docker logs <l3afd-container-id>
-```
 
 # Contributing
 Contributing to L3afd is fun. To get started:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,35 @@ go test -tags WINDOWS ./...
 # Generate Swagger Docs
 See our [Swaggo setup](docs/swagger.md)
 
+# Build L3AFD Docker image
+- L3afd binary & configuration that is required in the Docker image needs to be built locally and copied to build-docker directory
+- Execute below command to build the docker image 
+```
+docker build -t l3afd:r2 -f Dockerfile.l3afd .
+```
+Note: l3afd:r2 => <docker-build-name>:<tag> Name and build tag can be changed accordingly
+
+# Run L3AFD Docker Container 
+Requirements to run L3afd as a Container
+- BPF, debugfs & shared-memory filesystems mount points should be available in the Container
+- L3afd container needs Privileged access as it needs to perform attach/detach of eBPF programs
+- eBPF programs should be attached to the Host interface so that it will apply to all the Containers in the Host
+
+In order to satisfy the above requirements L3afd docker container needs to be run using the below command
+```
+docker run -d -v /sys/fs/bpf:/sys/fs/bpf -v /sys/kernel/debug/:/sys/kernel/debug/ -v /dev/shm:/dev/shm --privileged --net=host l3afd:r2
+```
+
+Command to connect to L3afd container shell
+```
+docker exec -it <container> /bin/bashL3afd logs
+```
+
+Command to check L3afd logs
+```
+docker logs <l3afd-container-id>
+```
+
 # Contributing
 Contributing to L3afd is fun. To get started:
 - [Contributing guide](docs/CONTRIBUTING.md)

--- a/build-docker/Dockerfile
+++ b/build-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:jammy@sha256:6d7b5d3317a71adb5e175640150e44b8b9a9401a7dd394f44840626aff9fa94d
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -16,14 +16,14 @@ RUN apt-get update && \
     cmake \
     zlib1g-dev \
     libevent-dev \
-            vim \
-            wget \
-            curl \
-            linux-tools-generic \
-            net-tools \
-            iproute2 \
-            elfutils \
-            libjson-c-dev \
+    vim \
+    wget \
+    curl \
+    linux-tools-generic \
+    net-tools \
+    iproute2 \
+    elfutils \
+    libjson-c-dev \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/build-docker/Dockerfile
+++ b/build-docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+# Install necessary dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    clang \
+    llvm \
+    libelf-dev \
+    linux-headers-$(uname -r) \
+    libbpf-dev \
+    tzdata \
+    cmake \
+    zlib1g-dev \
+    libevent-dev \
+            vim \
+            wget \
+            curl \
+            linux-tools-generic \
+            net-tools \
+            iproute2 \
+            elfutils \
+            libjson-c-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /srv/l3afd/
+RUN mkdir -p /var/l3afd
+RUN mkdir -p /var/log/l3af
+
+COPY l3afd /root/l3afd
+COPY l3afd.cfg /root/l3afd.cfg
+
+ENTRYPOINT ["/root/l3afd", "--config", "/root/l3afd.cfg"]


### PR DESCRIPTION
Changes
---------
- Added Dockerfile to build the Docker image for L3AFD
- Update README with the instructions to build L3AFD Docker image and run it in a Container

Testing
-------
- Able to attach XDP and TC programs using L3AFD Container