### PR TITLE
Fixing incomplete execution of the configuration issue

### DIFF
--- a/bpfprogs/nfconfig.go
+++ b/bpfprogs/nfconfig.go
@@ -764,13 +764,6 @@ func (c *NFConfigs) DeployeBPFPrograms(bpfProgs []models.L3afBPFPrograms) error 
 
 	for _, bpfProg := range bpfProgs {
 		if err := c.Deploy(bpfProg.Iface, bpfProg.HostName, bpfProg.BpfPrograms); err != nil {
-			if err := c.SaveConfigsToConfigStore(); err != nil {
-				if combinedError == nil { // saving all the errors for c.Deploy c.SaveConfigsToConfigStore to combinedError instead of returning right away.
-					combinedError = fmt.Errorf("deploy eBPF Programs failed to save configs %w", err)
-				} else {
-					combinedError = fmt.Errorf("%v; %v", combinedError, fmt.Errorf("deploy eBPF Programs failed to save configs %w", err))
-				}
-			}
 			if combinedError == nil {
 				combinedError = fmt.Errorf("deploy eBPF Programs failed to save configs %w", err)
 			} else {
@@ -783,9 +776,6 @@ func (c *NFConfigs) DeployeBPFPrograms(bpfProgs []models.L3afBPFPrograms) error 
 			c.Ifaces[bpfProg.Iface] = bpfProg.Iface
 		}
 	}
-	if combinedError != nil {
-		return combinedError
-	}
 
 	if err := c.RemoveMissingNetIfacesNBPFProgsInConfig(bpfProgs); err != nil {
 		log.Warn().Err(err).Msgf("Remove missing interfaces and BPF programs in the config failed with error ")
@@ -793,10 +783,8 @@ func (c *NFConfigs) DeployeBPFPrograms(bpfProgs []models.L3afBPFPrograms) error 
 	if err := c.SaveConfigsToConfigStore(); err != nil {
 		return fmt.Errorf("deploy eBPF Programs failed to save configs %w", err)
 	}
-	return nil
+	return combinedError
 }
-
-// function to combine all errors in []error and return a single error
 
 // SaveConfigsToConfigStore - Writes configs to persistent store
 func (c *NFConfigs) SaveConfigsToConfigStore() error {

--- a/bpfprogs/nfconfig.go
+++ b/bpfprogs/nfconfig.go
@@ -8,6 +8,7 @@ import (
 	"container/list"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -764,12 +765,9 @@ func (c *NFConfigs) DeployeBPFPrograms(bpfProgs []models.L3afBPFPrograms) error 
 
 	for _, bpfProg := range bpfProgs {
 		if err := c.Deploy(bpfProg.Iface, bpfProg.HostName, bpfProg.BpfPrograms); err != nil {
-			if combinedError == nil {
-				combinedError = fmt.Errorf("deploy eBPF Programs failed to save configs %w", err)
-			} else {
-				combinedError = fmt.Errorf("%v; %v", combinedError, fmt.Errorf("failed to deploy BPF program on iface %s with error: %w", bpfProg.Iface, err))
-			}
+			combinedError = errors.Join(combinedError, fmt.Errorf("failed to deploy BPF program on iface %s with error: %w", bpfProg.Iface, err))
 		}
+
 		if len(c.Ifaces) == 0 {
 			c.Ifaces = map[string]string{bpfProg.Iface: bpfProg.Iface}
 		} else {

--- a/bpfprogs/nfconfig.go
+++ b/bpfprogs/nfconfig.go
@@ -779,7 +779,7 @@ func (c *NFConfigs) DeployeBPFPrograms(bpfProgs []models.L3afBPFPrograms) error 
 		log.Warn().Err(err).Msgf("Remove missing interfaces and BPF programs in the config failed with error ")
 	}
 	if err := c.SaveConfigsToConfigStore(); err != nil {
-		return fmt.Errorf("deploy eBPF Programs failed to save configs %w", err)
+		combinedError = errors.Join(combinedError, fmt.Errorf("deploy eBPF Programs failed to save configs %w", err))
 	}
 	return combinedError
 }


### PR DESCRIPTION
Addressing https://github.com/l3af-project/l3afd/issues/520
In case the payload consist of the configuration which requires eBPF programs for multiple interfaces to be loaded (for example, eth1, eth2, and eth3). 

In the scenario where eth2 exists no more:
- Due to the return statements in the sequential for loop in the current l3afd code will load the eBPF program for eth1, and return directly as eth2 will not be found, without even attempting to load the eBPF program for eth3. 

In this PR, we remove the return statements in the for loop and instead save individual error messages to single variable. This  variable is then returned after the for loop is completed.