### PR TITLE
Update tcx support

### DIFF
--- a/.github/workflows/ci-build-windows.yaml
+++ b/.github/workflows/ci-build-windows.yaml
@@ -21,10 +21,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Setup Go 1.22.3
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+      - name: Setup Go 1.23.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
 
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -21,10 +21,10 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - name: Setup Go 1.22.3
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+      - name: Setup Go 1.23.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
 
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481

--- a/bpfprogs/bpf_windows.go
+++ b/bpfprogs/bpf_windows.go
@@ -62,6 +62,12 @@ func (b *BPF) LoadTCAttachProgram(ifaceName, direction string) error {
 	return fmt.Errorf("LoadTCAttachProgram - TC programs Unsupported on windows")
 }
 
+// LoadTCXAttachProgram - not implemented in windows
+func (b *BPF) LoadTCXAttachProgram(ifaceName, direction string) error {
+	// not implement nothing todo
+	return fmt.Errorf("LoadTCXAttachProgram - TC programs Unsupported on windows")
+}
+
 // UnloadTCProgram - Remove TC filters
 func (b *BPF) UnloadTCProgram(ifaceName, direction string) error {
 	return fmt.Errorf("UnloadTCProgram - TC programs Unsupported on windows")

--- a/bpfprogs/nfconfig.go
+++ b/bpfprogs/nfconfig.go
@@ -1558,9 +1558,9 @@ func SerialzeProgram(e *list.Element) *models.L3AFMetaData {
 			}
 		}
 	}
-	tmp.XDPLink = false
-	if bpf.XDPLink != nil {
-		tmp.XDPLink = true
+	tmp.Link = false
+	if bpf.Link != nil {
+		tmp.Link = true
 	}
 	return tmp
 }

--- a/models/l3afd.go
+++ b/models/l3afd.go
@@ -152,7 +152,7 @@ type L3AFMetaData struct {
 	ProgMapCollection MetaColl
 	ProgMapID         uint32
 	PrevProgMapID     uint32
-	XDPLink           bool
+	Link              bool
 }
 
 type L3AFALLHOSTDATA struct {

--- a/restart/restart.go
+++ b/restart/restart.go
@@ -150,10 +150,10 @@ func deserializeProgram(ctx context.Context, r *models.L3AFMetaData, hostconfig 
 		Programs: make(map[string]*ebpf.Program),
 		Maps:     make(map[string]*ebpf.Map),
 	}
-	if r.XDPLink {
+	if r.Link {
 		linkPinPath := fmt.Sprintf("%s/links/%s/%s_%s", hostconfig.BpfMapDefaultPath, iface, g.Program.Name, g.Program.ProgType)
 		var err error
-		g.XDPLink, err = link.LoadPinnedLink(linkPinPath, nil)
+		g.Link, err = link.LoadPinnedLink(linkPinPath, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR introduces the capability to attach Traffic Control (tc) programs using TCX APIs, a feature supported starting from Linux kernel version 6.8. 