### PR TITLE
Update tcx support

### DIFF
--- a/.github/workflows/ci-build-windows.yaml
+++ b/.github/workflows/ci-build-windows.yaml
@@ -21,10 +21,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Setup Go 1.22.3
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+      - name: Setup Go 1.23.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
 
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -21,10 +21,10 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - name: Setup Go 1.22.3
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+      - name: Setup Go 1.23.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
 
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481

--- a/bpfprogs/bpf.go
+++ b/bpfprogs/bpf.go
@@ -30,6 +30,7 @@ import (
 	"github.com/l3af-project/l3afd/v2/config"
 	"github.com/l3af-project/l3afd/v2/models"
 	"github.com/l3af-project/l3afd/v2/stats"
+	"github.com/l3af-project/l3afd/v2/utils"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -188,13 +189,16 @@ func LoadRootProgram(ifaceName string, direction string, progType string, conf *
 		if err := rootProgBPF.ProgMapCollection.Programs[rootProgBPF.Program.EntryFunctionName].Pin(progPinPath); err != nil {
 			return nil, err
 		}
-	} else if progType == models.TCType {
-		if err := rootProgBPF.LoadTCXAttachProgram(ifaceName, direction); err != nil {
+	} else {
+		if utils.CheckTCXSupport() {
+			if err := rootProgBPF.LoadTCXAttachProgram(ifaceName, direction); err != nil {
+				return nil, fmt.Errorf("failed to load tcx root program on iface \"%s\" name %s direction %s with err %w", ifaceName, rootProgBPF.Program.Name, direction, err)
+			}
+		} else {
 			if err := rootProgBPF.LoadTCAttachProgram(ifaceName, direction); err != nil {
 				return nil, fmt.Errorf("failed to load tc root program on iface \"%s\" name %s direction %s with err %w", ifaceName, rootProgBPF.Program.Name, direction, err)
 			}
 		}
-
 		// pin the program also
 		progPinPath := fmt.Sprintf("%s/progs/%s/%s_%s", rootProgBPF.HostConfig.BpfMapDefaultPath, ifaceName, rootProgBPF.Program.EntryFunctionName, rootProgBPF.Program.ProgType)
 		if err := rootProgBPF.ProgMapCollection.Programs[rootProgBPF.Program.EntryFunctionName].Pin(progPinPath); err != nil {
@@ -975,9 +979,13 @@ func (b *BPF) UnloadProgram(ifaceName, direction string) error {
 	// SeqID will be 0 for root program or any other program without chaining
 	if b.Program.SeqID == 0 || !b.HostConfig.BpfChainingEnabled {
 		if b.Program.ProgType == models.TCType {
-			if b.Link != nil {
-				if err := b.Link.Close(); err != nil {
-					log.Warn().Msgf("removing tc attached program failed iface %q direction %s error - %v", ifaceName, direction, err)
+			if utils.CheckTCXSupport() {
+				if b.Link != nil {
+					if err := b.Link.Close(); err != nil {
+						log.Warn().Msgf("removing tc attached program %s failed iface %q direction %s error - %v", b.Program.Name, ifaceName, direction, err)
+					}
+				} else {
+					log.Warn().Msgf("attach program %s link file is missing iface %q direction %s", b.Program.Name, ifaceName, direction)
 				}
 			} else {
 				if err := b.UnloadTCProgram(ifaceName, direction); err != nil {
@@ -1385,6 +1393,7 @@ func (b *BPF) AttachBPFProgram(ifaceName, direction string) error {
 			return err
 		}
 	} else if b.Program.ProgType == models.TCType {
+
 		if err := b.LoadTCXAttachProgram(ifaceName, direction); err != nil {
 			if err := b.LoadTCAttachProgram(ifaceName, direction); err != nil {
 				return fmt.Errorf("failed to attach tc program %s to inferface %s direction %s with err: %w", b.Program.Name, ifaceName, direction, err)

--- a/bpfprogs/bpf_unix.go
+++ b/bpfprogs/bpf_unix.go
@@ -194,8 +194,8 @@ func VerifyNCreateTCDirs() error {
 		return nil
 	}
 	log.Info().Msgf(" %s tc directory doesn't exists, creating", path)
-	err := os.MkdirAll(path, 0700)
-	if err != nil {
+
+	if err := os.MkdirAll(path, 0700); err != nil {
 		return fmt.Errorf("unable to create directories to pin tc maps %s : %w", path, err)
 	}
 	return nil

--- a/bpfprogs/bpf_windows.go
+++ b/bpfprogs/bpf_windows.go
@@ -62,6 +62,12 @@ func (b *BPF) LoadTCAttachProgram(ifaceName, direction string) error {
 	return fmt.Errorf("LoadTCAttachProgram - TC programs Unsupported on windows")
 }
 
+// LoadTCXAttachProgram - not implemented in windows
+func (b *BPF) LoadTCXAttachProgram(ifaceName, direction string) error {
+	// not implement nothing todo
+	return fmt.Errorf("LoadTCXAttachProgram - TC programs Unsupported on windows")
+}
+
 // UnloadTCProgram - Remove TC filters
 func (b *BPF) UnloadTCProgram(ifaceName, direction string) error {
 	return fmt.Errorf("UnloadTCProgram - TC programs Unsupported on windows")

--- a/bpfprogs/nfconfig.go
+++ b/bpfprogs/nfconfig.go
@@ -1558,9 +1558,9 @@ func SerialzeProgram(e *list.Element) *models.L3AFMetaData {
 			}
 		}
 	}
-	tmp.XDPLink = false
-	if bpf.XDPLink != nil {
-		tmp.XDPLink = true
+	tmp.Link = false
+	if bpf.Link != nil {
+		tmp.Link = true
 	}
 	return tmp
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ import (
 	"github.com/l3af-project/l3afd/v2/pidfile"
 	"github.com/l3af-project/l3afd/v2/restart"
 	"github.com/l3af-project/l3afd/v2/stats"
+	"github.com/l3af-project/l3afd/v2/utils"
+
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/rs/zerolog"
@@ -175,7 +177,7 @@ func SetupNFConfigs(ctx context.Context, conf *config.Config) (*bpfprogs.NFConfi
 func checkKernelVersion(conf *config.Config) error {
 	const minVerLen = 2
 
-	kernelVersion, err := getKernelVersion()
+	kernelVersion, err := utils.GetKernelVersion()
 	if err != nil {
 		return fmt.Errorf("failed to find kernel version: %v", err)
 	}
@@ -202,20 +204,6 @@ func checkKernelVersion(conf *config.Config) error {
 	}
 
 	return fmt.Errorf("expected Kernel version >=  %d.%d", conf.MinKernelMajorVer, conf.MinKernelMinorVer)
-}
-
-func getKernelVersion() (string, error) {
-	osVersion, err := os.ReadFile("/proc/version")
-	if err != nil {
-		return "", fmt.Errorf("failed to read procfs: %v", err)
-	}
-	var u1, u2, kernelVersion string
-	_, err = fmt.Sscanf(string(osVersion), "%s %s %s", &u1, &u2, &kernelVersion)
-	if err != nil {
-		return "", fmt.Errorf("failed to scan procfs version: %v", err)
-	}
-
-	return kernelVersion, nil
 }
 
 func ReadConfigsFromConfigStore(conf *config.Config) ([]models.L3afBPFPrograms, error) {

--- a/models/l3afd.go
+++ b/models/l3afd.go
@@ -152,7 +152,7 @@ type L3AFMetaData struct {
 	ProgMapCollection MetaColl
 	ProgMapID         uint32
 	PrevProgMapID     uint32
-	XDPLink           bool
+	Link              bool
 }
 
 type L3AFALLHOSTDATA struct {

--- a/restart/restart.go
+++ b/restart/restart.go
@@ -125,7 +125,7 @@ func getMetricsMaps(input map[string]models.MetaMetricsBPFMap, b *bpfprogs.BPF, 
 }
 
 // deserializeProgram will deserialize individual program from given *models.L3AFMetaData
-func deserializeProgram(ctx context.Context, r *models.L3AFMetaData, hostconfig *config.Config, iface string) (*bpfprogs.BPF, error) {
+func deserializeProgram(ctx context.Context, r *models.L3AFMetaData, hostconfig *config.Config, iface, direction string) (*bpfprogs.BPF, error) {
 	g := &bpfprogs.BPF{}
 	g.Program = r.Program
 	g.FilePath = r.FilePath
@@ -151,7 +151,12 @@ func deserializeProgram(ctx context.Context, r *models.L3AFMetaData, hostconfig 
 		Maps:     make(map[string]*ebpf.Map),
 	}
 	if r.Link {
-		linkPinPath := fmt.Sprintf("%s/links/%s/%s_%s", hostconfig.BpfMapDefaultPath, iface, g.Program.Name, g.Program.ProgType)
+		var linkPinPath string
+		if g.Program.ProgType == models.XDPType {
+			linkPinPath = fmt.Sprintf("%s/links/%s/%s_%s", hostconfig.BpfMapDefaultPath, iface, g.Program.Name, g.Program.ProgType)
+		} else {
+			linkPinPath = fmt.Sprintf("%s/links/%s/%s_%s_%s", hostconfig.BpfMapDefaultPath, iface, g.Program.Name, g.Program.ProgType, direction)
+		}
 		var err error
 		g.Link, err = link.LoadPinnedLink(linkPinPath, nil)
 		if err != nil {
@@ -221,7 +226,7 @@ func Convert(ctx context.Context, t models.L3AFALLHOSTDATA, hostconfig *config.C
 		for k, v := range t.IngressXDPBpfs {
 			l := list.New()
 			for _, r := range v {
-				f, err := deserializeProgram(ctx, r, hostconfig, k)
+				f, err := deserializeProgram(ctx, r, hostconfig, k, models.XDPIngressType)
 				if err != nil {
 					log.Err(err).Msg("Deserialization failed for xdp ingress programs")
 					return nil, err
@@ -235,7 +240,7 @@ func Convert(ctx context.Context, t models.L3AFALLHOSTDATA, hostconfig *config.C
 		for k, v := range t.IngressTCBpfs {
 			l := list.New()
 			for _, r := range v {
-				f, err := deserializeProgram(ctx, r, hostconfig, k)
+				f, err := deserializeProgram(ctx, r, hostconfig, k, models.IngressType)
 				if err != nil {
 					log.Err(err).Msg("Deserialization failed for tc ingress programs")
 					return nil, err
@@ -249,7 +254,7 @@ func Convert(ctx context.Context, t models.L3AFALLHOSTDATA, hostconfig *config.C
 		for k, v := range t.EgressTCBpfs {
 			l := list.New()
 			for _, r := range v {
-				f, err := deserializeProgram(ctx, r, hostconfig, k)
+				f, err := deserializeProgram(ctx, r, hostconfig, k, models.EgressType)
 				if err != nil {
 					log.Err(err).Msg("Deserialization failed for tc egress programs")
 					return nil, err

--- a/restart/restart.go
+++ b/restart/restart.go
@@ -150,10 +150,10 @@ func deserializeProgram(ctx context.Context, r *models.L3AFMetaData, hostconfig 
 		Programs: make(map[string]*ebpf.Program),
 		Maps:     make(map[string]*ebpf.Map),
 	}
-	if r.XDPLink {
+	if r.Link {
 		linkPinPath := fmt.Sprintf("%s/links/%s/%s_%s", hostconfig.BpfMapDefaultPath, iface, g.Program.Name, g.Program.ProgType)
 		var err error
-		g.XDPLink, err = link.LoadPinnedLink(linkPinPath, nil)
+		g.Link, err = link.LoadPinnedLink(linkPinPath, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR introduces the capability to attach Traffic Control (tc) programs using TCX APIs, a feature supported starting from Linux kernel version 6.8.