### PR TITLE
Update log max backup default value

### DIFF
--- a/bpfprogs/bpfmetrics.go
+++ b/bpfprogs/bpfmetrics.go
@@ -48,7 +48,7 @@ func (c *BpfMetrics) BpfMetricsWorker(bpfProgs map[string]*list.List) {
 					continue
 				}
 				if err := bpf.MonitorMaps(ifaceName, c.Intervals); err != nil {
-					log.Error().Err(err).Msgf("pMonitor monitor maps failed - %s", bpf.Program.Name)
+					log.Debug().Err(err).Msgf("pMonitor monitor maps failed - %s", bpf.Program.Name)
 				}
 			}
 		}
@@ -67,7 +67,7 @@ func (c *BpfMetrics) BpfMetricsProbeWorker(bpfProgs *list.List) {
 				continue
 			}
 			if err := bpf.MonitorMaps("", c.Intervals); err != nil {
-				log.Error().Err(err).Msgf("pMonitor probe monitor maps failed - %s", bpf.Program.Name)
+				log.Debug().Err(err).Msgf("pMonitor probe monitor maps failed - %s", bpf.Program.Name)
 			}
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -119,7 +119,7 @@ func ReadConfig(configPath string) (*Config, error) {
 		MinKernelMinorVer:              LoadOptionalConfigInt(confReader, "l3afd", "kernel-minor-version", 15),
 		FileLogLocation:                LoadOptionalConfigString(confReader, "l3afd", "file-log-location", ""),
 		FileLogMaxSize:                 LoadOptionalConfigInt(confReader, "l3afd", "file-log-max-size", 100),
-		FileLogMaxBackups:              LoadOptionalConfigInt(confReader, "l3afd", "file-log-max-backups", 20),
+		FileLogMaxBackups:              LoadOptionalConfigInt(confReader, "l3afd", "file-log-max-backups", 10),
 		FileLogMaxAge:                  LoadOptionalConfigInt(confReader, "l3afd", "file-log-max-age", 60),
 		JSONFormatLogs:                 LoadOptionalConfigBool(confReader, "l3afd", "json-format-logs", false),
 		EBPFRepoURL:                    LoadConfigString(confReader, "ebpf-repo", "url"),


### PR DESCRIPTION
This PR updates the default value for log max backups to 10. It also changes monitor error logs to debug level, which will help reduce multiple log entries in a goroutine.