### PR TITLE
Update to support ebpf pkg v0.18.0 or higher

### DIFF
--- a/bpfprogs/bpf_windows.go
+++ b/bpfprogs/bpf_windows.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"github.com/cilium/ebpf"
 )
 
 // DisableLRO - XDP programs are failing when Large Receive Offload is enabled, to fix this we use to manually disable.
@@ -70,5 +72,18 @@ func (b *BPF) LoadTCXAttachProgram(ifaceName, direction string) error {
 
 // UnloadTCProgram - Remove TC filters
 func (b *BPF) UnloadTCProgram(ifaceName, direction string) error {
+	// not implement nothing todo
 	return fmt.Errorf("UnloadTCProgram - TC programs Unsupported on windows")
+}
+
+// LoadXDPAttachProgram - Attaches XDP program to interface
+func (b *BPF) LoadXDPAttachProgram(ifaceName string) error {
+	// not implement nothing todo
+	return fmt.Errorf("LoadXDPAttachProgram - AttachXDP method is Unsupported on windows")
+}
+
+// LoadBPFProgramProbeType - Loads Probe type bpf program
+func (b *BPF) LoadBPFProgramProbeTypes(objSpec *ebpf.CollectionSpec) error {
+	// not implement nothing todo
+	return fmt.Errorf("LoadBPFProgramProbeTypes - Probes are Unsupported on windows")
 }

--- a/bpfprogs/probes.go
+++ b/bpfprogs/probes.go
@@ -1,5 +1,8 @@
 // Copyright Contributors to the L3AF Project.
 // SPDX-License-Identifier: Apache-2.0
+//
+//go:build !WINDOWS
+// +build !WINDOWS
 
 package bpfprogs
 

--- a/bpfprogs/probes_test.go
+++ b/bpfprogs/probes_test.go
@@ -1,5 +1,8 @@
 // Copyright Contributors to the L3AF Project.
 // SPDX-License-Identifier: Apache-2.0
+//
+//go:build !WINDOWS
+// +build !WINDOWS
 
 package bpfprogs
 


### PR DESCRIPTION
This PR fixes the Windows build failure occurring with eBPF v0.18.0 or later.