### PR TITLE
Use generic Linux headers for Docker build

### DIFF
--- a/build-docker/Dockerfile
+++ b/build-docker/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && \
     clang \
     llvm \
     libelf-dev \
-    linux-headers-$(uname -r) \
+    linux-headers-generic \
+    linux-tools-common linux-tools-generic \
     libbpf-dev \
     tzdata \
     cmake \


### PR DESCRIPTION
This PR removes kernel-specific header dependencies in favor of generic Linux headers for the Docker build.