### PR TITLE
Update the endpoints to listen on localhost

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,7 @@ func ReadConfig(configPath string) (*Config, error) {
 		HttpClientTimeout:              LoadOptionalConfigDuration(confReader, "l3afd", "http-client-timeout", 30*time.Second),
 		MaxEBPFReStartCount:            LoadOptionalConfigInt(confReader, "l3afd", "max-ebpf-restart-count", 3),
 		BpfChainingEnabled:             LoadConfigBool(confReader, "l3afd", "bpf-chaining-enabled"),
-		MetricsAddr:                    LoadConfigString(confReader, "web", "metrics-addr"),
+		MetricsAddr:                    LoadOptionalConfigString(confReader, "web", "metrics-addr", "localhost:8898"),
 		EBPFPollInterval:               LoadOptionalConfigDuration(confReader, "web", "ebpf-poll-interval", 30*time.Second),
 		NMetricSamples:                 LoadOptionalConfigInt(confReader, "web", "n-metric-samples", 20),
 		ShutdownTimeout:                LoadOptionalConfigDuration(confReader, "l3afd", "shutdown-timeout", 25*time.Second),

--- a/config/l3afd.cfg
+++ b/config/l3afd.cfg
@@ -25,7 +25,7 @@ url: file:///srv/l3afd
 
 
 [web]
-metrics-addr: 0.0.0.0:8898
+metrics-addr: localhost:8898
 ebpf-poll-interval: 30s
 n-metric-samples: 20
 
@@ -51,11 +51,11 @@ ingress-entry-function-name: tc_ingress_root
 egress-entry-function-name: tc_egress_root
 
 [ebpf-chain-debug]
-addr: 0.0.0.0:8899
+addr: localhost:8899
 enabled: true
 
 [l3af-configs]
-restapi-addr: 0.0.0.0:7080
+restapi-addr: localhost:7080
 
 [l3af-config-store]
 filename: /var/l3afd/l3af-config.json


### PR DESCRIPTION
This PR changes the default values of metrics-addr, restapi-addr, and ebpf-chain-debug to listen on localhost.