### PR TITLE
Fix delete api corrupting the local cache

### DIFF
--- a/bpfprogs/nfconfig.go
+++ b/bpfprogs/nfconfig.go
@@ -1427,7 +1427,6 @@ func (c *NFConfigs) DeleteProgramsOnInterfaceHelper(e *list.Element, ifaceName s
 func (c *NFConfigs) DeleteEbpfPrograms(bpfProgs []models.L3afBPFProgramNames) error {
 	var combinedError error
 	for _, bpfProg := range bpfProgs {
-		c.Ifaces = map[string]string{bpfProg.Iface: bpfProg.IPv4Address}
 		if err := c.DeleteProgramsOnInterface(bpfProg.Iface, bpfProg.HostName, bpfProg.BpfProgramNames); err != nil {
 			if err := c.SaveConfigsToConfigStore(); err != nil {
 				combinedError = errors.Join(combinedError, fmt.Errorf("SaveConfigsToConfigStore failed to save configs %w", err))


### PR DESCRIPTION
This PR prevents local cache corruption by removing the IPv4 address update in the delete api.